### PR TITLE
fix: use StrEnum to resolve ruff UP042 lint failure

### DIFF
--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
 
-class DependentType(str, Enum):
+class DependentType(StrEnum):
     """Type of dependent to search for."""
 
     REPOSITORY = "REPOSITORY"


### PR DESCRIPTION
## Summary
- Replace `class DependentType(str, Enum)` with `class DependentType(StrEnum)` in `models.py`
- Fixes CI failure introduced by ruff 0.15.8's new `UP042` rule which flags the legacy `(str, Enum)` mixin pattern
- `StrEnum` (Python 3.11+) is a drop-in replacement — all 114 tests pass, no behavior change

## Context
The Dependabot PR to bump ruff to 0.15.8 (`dependabot/uv/ruff-0.15.8`) fails CI because of this lint violation. This fix should be merged first, then the ruff bump PR will pass.

**Note:** The Dependabot auto-approve workflow also fails on 3 PRs due to a repo settings issue — "Allow GitHub Actions to create and approve pull requests" needs to be enabled in Settings → Actions → General.

## Test plan
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/dep_rank/` — passes
- [x] `uv run pytest` — 114/114 tests pass, 98% coverage