### PR TITLE
chore: set up PyPI release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,195 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: CI gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: "3.11"
+      - run: uv sync
+      - run: uv run ruff check src/ tests/
+      - run: uv run mypy src/dep_rank/
+      - run: uv run pytest
+
+  build:
+    name: Build distributions
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify tag is on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
+            echo "ERROR: Tagged commit $(git rev-parse --short HEAD) is not on main"
+            exit 1
+          fi
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Verify distributions
+        run: |
+          ls -la dist/
+          WHEEL=$(ls dist/*.whl 2>/dev/null | wc -l)
+          SDIST=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
+          if [ "$WHEEL" -eq 0 ] || [ "$SDIST" -eq 0 ]; then
+            echo "ERROR: Expected both a wheel and sdist in dist/"
+            ls dist/
+            exit 1
+          fi
+          echo "Build produced: $(ls dist/)"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/dep-rank
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Verify TestPyPI install
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Waiting for dep-rank==${VERSION} to appear on TestPyPI..."
+          for i in 1 2 3 4 5; do
+            sleep $((i * 30))
+            if pip install \
+              --index-url https://test.pypi.org/simple/ \
+              --extra-index-url https://pypi.org/simple/ \
+              "dep-rank==${VERSION}" 2>/dev/null; then
+              ACTUAL=$(dep-rank --version 2>&1)
+              echo "Installed version: ${ACTUAL}"
+              echo "${ACTUAL}" | grep -qF "${VERSION}" || {
+                echo "ERROR: Expected '${VERSION}' in dep-rank --version output"
+                exit 1
+              }
+              echo "TestPyPI install OK"
+              exit 0
+            fi
+            echo "Attempt $i: not yet available, retrying..."
+          done
+          echo "ERROR: dep-rank==${VERSION} not available on TestPyPI after 7.5 minutes"
+          exit 1
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, publish-testpypi]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/dep-rank
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+
+  github-release:
+    name: Create GitHub Release
+    needs: [build, publish-pypi]
+    if: needs.publish-pypi.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Classify tag (stable vs prerelease)
+        id: classify
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release with assets
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          generate_release_notes: true
+          draft: true
+          prerelease: ${{ steps.classify.outputs.prerelease }}
+          files: dist/*

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,27 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semver bump (auto = infer from Conventional Commits)"
+        type: choice
+        required: true
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
+    with:
+      bump: ${{ inputs.bump }}
+      tag-prefix: "v"
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .vscode
 docs/
 .worktrees/
+src/dep_rank/_version.py

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,117 @@
+# Release Guide
+
+Quick reference for maintainers releasing a new version of `dep-rank`.
+
+## Prerequisites
+
+These are already configured. Verify once if something seems broken:
+
+- [ ] CI is passing on `main`
+- [ ] PyPI Trusted Publisher configured for the `pypi` environment
+  (Settings → Environments → `pypi` → required reviewer set)
+- [ ] TestPyPI Trusted Publisher configured for the `testpypi` environment
+- [ ] Both environments use OIDC — no API tokens needed
+- [ ] `Release Bot` GitHub App installed on this repo (needed to push signed
+  tags; bypasses the recursion guard that blocks `GITHUB_TOKEN` tag pushes)
+- [ ] `RELEASE_BOT_PRIVATE_KEY` secret stored at repo level
+  (Settings → Secrets and variables → Actions → Repository secrets)
+
+---
+
+## Releasing a New Version
+
+### Stable release (UI-driven, recommended)
+
+1. Go to **Actions → Tag Release → Run workflow**
+2. Select the `main` branch and pick a `bump`:
+   - `auto` — infer from Conventional Commits since the last tag
+     (`feat:` → minor, `fix:` / `chore:` / `docs:` → patch,
+     `<type>!:` or `BREAKING CHANGE:` → major)
+   - `patch` / `minor` / `major` — override the auto analysis
+3. Click **Run workflow**. The shared `tag-release.yml` reusable workflow
+   computes the next version, creates and pushes a signed `vX.Y.Z` tag
+   via the Release Bot App
+4. The `v*` tag push triggers `publish.yml` (test → build → TestPyPI →
+   PyPI → GitHub Release)
+
+The "auto" bump analyzer reads commit subjects since the last tag, so
+**Conventional Commits** matter: every commit in a PR should match the PR's
+user-visible intent, not the per-commit diff shape. A stray `feat:` in an
+otherwise-`fix:` PR will flip a patch release to minor.
+
+### Pre-release (manual tag push)
+
+The UI only offers `auto/patch/minor/major`, so pre-releases use a manual
+tag push. The same `publish.yml` runs and the classifier flags the release
+as prerelease automatically:
+
+    git checkout main && git pull origin main
+    git tag v0.2.0rc1       # or v0.2.0a1, v0.2.0b1, v0.2.0.dev1
+    git push origin v0.2.0rc1
+
+Use **PEP 440 canonical** forms (no hyphens): `a1` / `b1` / `rc1` / `.dev1`.
+
+---
+
+## What Happens Next (Automated)
+
+The `publish.yml` workflow runs five jobs in sequence:
+
+| Job | What it does |
+|-----|--------------|
+| `test` | Runs linting, type checking, and tests as a CI gate |
+| `build` | Verifies the tag is on `main`, builds sdist + wheel via `uv build`, uploads artifacts |
+| `publish-testpypi` | Publishes to TestPyPI, polls for availability, installs and smoke-tests the package |
+| `publish-pypi` | **Waits for a required reviewer to approve** the `pypi` environment, then publishes |
+| `github-release` | Creates a **draft** GitHub Release with auto-generated notes and attached artifacts |
+
+Monitor progress at:
+`https://github.com/j7an/dep-rank/actions`
+
+---
+
+## After the Workflow Completes
+
+- [ ] Approve the `pypi` environment deployment when GitHub prompts you
+- [ ] Verify the live package: `pip install "dep-rank==${VERSION}"`
+- [ ] Smoke-test: `dep-rank --version`
+- [ ] Open the draft GitHub Release, review auto-generated notes, and click **Publish release**
+
+---
+
+## Recovering from a Failed Release
+
+### Build job failed (stable release)
+
+The tag already exists. Fix the issue on `main`, then delete the tag and
+re-run the Tag Release workflow:
+
+    git tag -d "v${VERSION}"
+    git push origin ":refs/tags/v${VERSION}"
+    # merge the fix to main, then:
+    # Actions → Tag Release → Run workflow → same bump as before
+
+### Build job failed (pre-release)
+
+Same delete-and-re-push, but the re-tag is manual:
+
+    git tag -d "v${VERSION}"
+    git push origin ":refs/tags/v${VERSION}"
+    # merge the fix to main, then:
+    git tag "v${VERSION}" && git push origin "v${VERSION}"
+
+### Published to TestPyPI but PyPI failed
+
+The wheel and sdist are already uploaded to TestPyPI (immutable). You can
+publish to PyPI manually using the artifacts from the failed workflow run,
+or bump to a patch version and re-release via the Tag Release workflow.
+
+### GitHub Release not created
+
+The `github-release` job only runs if `publish-pypi` succeeds. If it was
+skipped, create the release manually:
+
+    gh release create "v${VERSION}" dist/* \
+      --title "v${VERSION}" \
+      --generate-notes \
+      --draft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ addopts = "--cov=dep_rank --cov-report=term-missing --cov-fail-under=80"
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+extend-exclude = ["src/dep_rank/_version.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "S", "B", "A", "C4", "T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dep-rank"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Analyze GitHub repository dependents by star count. CLI + MCP server."
 requires-python = ">=3.11"
 license = "MIT"
@@ -53,11 +53,17 @@ dev = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dep_rank"]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/dep_rank/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/dep_rank/__init__.py
+++ b/src/dep_rank/__init__.py
@@ -1,3 +1,5 @@
 """dep-rank: Analyze GitHub repository dependents by star count."""
 
-__version__ = "0.1.0"
+from importlib.metadata import version
+
+__version__ = version("dep-rank")

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from click.testing import CliRunner
 
+from dep_rank import __version__
 from dep_rank.cli.app import cli
 from dep_rank.core.models import DependentsResult, DependentType, Repository, ScrapeResult
 
@@ -284,4 +285,4 @@ class TestVersionOption:
     def test_version(self, runner: CliRunner) -> None:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert __version__ in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,6 @@ wheels = [
 
 [[package]]
 name = "dep-rank"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -653,12 +652,13 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.1.1"
+version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -678,9 +678,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/83/c95d3bf717698a693eccb43e137a32939d2549876e884e246028bff6ecce/fastmcp-3.1.1.tar.gz", hash = "sha256:db184b5391a31199323766a3abf3a8bfbb8010479f77eca84c0e554f18655c48", size = 17347644, upload-time = "2026-03-14T19:12:20.235Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ea/570122de7e24f72138d006f799768e14cc1ccf7fcb22b7750b2bd276c711/fastmcp-3.1.1-py3-none-any.whl", hash = "sha256:8132ba069d89f14566b3266919d6d72e2ec23dd45d8944622dca407e9beda7eb", size = 633754, upload-time = "2026-03-14T19:12:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -795,6 +795,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Switch to dynamic versioning via `hatch-vcs` (Git tags → PEP 440 versions at build time, `importlib.metadata` at runtime)
- Add 5-stage gated publish workflow triggered on `v*` tags: test → build → TestPyPI → PyPI → GitHub Release
- Add tag-release workflow wrapping `j7an/shared-workflows` for one-click UI-driven releases
- Add release guide documenting the process for maintainers

Mirrors [nexus-mcp](https://github.com/j7an/nexus-mcp) release setup with these additions:
- CI gate job before build (linting + type checking + tests)
- Version-verified TestPyPI smoke test (`dep-rank --version` output checked)

All GitHub Actions are SHA-pinned. Publishing uses OIDC Trusted Publishers (no API tokens).

## Post-merge manual steps

1. Configure TestPyPI Trusted Publisher (owner: `j7an`, repo: `dep-rank`, workflow: `publish.yml`, env: `testpypi`)
2. Configure PyPI Trusted Publisher (same, env: `pypi`)
3. Create GitHub environments: `testpypi` (no protection), `pypi` (required reviewers)
4. Add `RELEASE_BOT_PRIVATE_KEY` repo secret (if not already available from nexus-mcp)
5. Tag and push: `git tag v0.1.0 && git push origin v0.1.0`

## Test plan

- [x] `uv sync` succeeds with hatch-vcs resolving version from Git history
- [x] `uv run python -c "from dep_rank import __version__; print(__version__)"` prints dev version
- [x] `pytest` — 126/128 pass (2 pre-existing failures unrelated to this PR)
- [x] `ruff check` — all passed
- [x] `mypy` — no issues in 15 source files
- [x] `uv build` — produces both sdist and wheel
- [ ] First real publish triggered by `v0.1.0` tag push (post-merge)