### PR TITLE
ci: create composite setup-uv action with --locked and caching

### DIFF
--- a/.github/actions/setup-uv/README.md
+++ b/.github/actions/setup-uv/README.md
@@ -1,0 +1,18 @@
+# setup-uv composite action
+
+Installs uv with dependency caching and runs `uv sync --locked` to install
+the project environment. Used by jobs that need a synced dev environment
+to run tests, linters, type-checkers, or `uv build`.
+
+## Inputs
+
+| Name             | Default | Description                          |
+| ---------------- | ------- | ------------------------------------ |
+| `python-version` | `3.11`  | Python version to install and use.   |
+
+## When NOT to use this action
+
+Skip this action and call `astral-sh/setup-uv` inline for jobs that:
+
+- Mutate the lockfile (`uv lock`) — `--locked` would fail on drift.
+- Don't need the project environment synced (e.g., `pre-commit autoupdate`).

--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,19 @@
+name: Setup uv
+description: Install uv with dependency caching and sync the project env (--locked).
+inputs:
+  python-version:
+    description: "Python version to install"
+    required: false
+    default: "3.11"
+runs:
+  using: "composite"
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+        python-version: ${{ inputs.python-version }}
+    - name: Sync dependencies (locked)
+      run: uv sync --locked
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+      - uses: ./.github/actions/setup-uv
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync
       - run: uv run ruff format --check src/ tests/
       - run: uv run ruff check src/ tests/
       - run: uv run mypy src/dep_rank/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
             exit 1
           fi
 
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: ./.github/actions/setup-uv
 
       - name: Build sdist and wheel
         run: uv build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
-        with:
-          python-version: "3.11"
-      - run: uv sync
+      - uses: ./.github/actions/setup-uv
       - run: uv run ruff check src/ tests/
       - run: uv run mypy src/dep_rank/
       - run: uv run pytest


### PR DESCRIPTION
## Summary

- Introduces `.github/actions/setup-uv/` composite action (action.yml + README.md) that installs uv with caching and runs `uv sync --locked`.
- Wires `ci.yml` test job and `publish.yml` test + build jobs to use the composite.
- Centralises uv setup logic; future `astral-sh/setup-uv` SHA bumps become one-line changes in the composite.

## Why

- **`--locked`**: fails fast when `pyproject.toml` and `uv.lock` diverge, catching drift at the sync step instead of running tests against silently re-resolved versions.
- **Caching**: `enable-cache: true` + `cache-dependency-glob: "uv.lock"` avoids re-downloading packages on every run. Each `(arch, OS, detected-Python, uv.lock hash)` tuple gets its own stable cache key (verified against `astral-sh/setup-uv` source at SHA cec20831 — `computeKeys` in `src/cache/restore-cache.ts`, `restoreCache(inputs, detectedPythonVersion)` in `src/setup-uv.ts`).
- **DRY**: three call sites previously duplicated the same 2-4 step setup pattern.

Adopted from `j7an/nexus-mcp`'s `.github/actions/setup-uv/action.yml`, adapted for dep-rank:
- Keeps dep-rank's existing `astral-sh/setup-uv@v8.0.0` pin (nexus uses v7 — we do not regress).
- Uses bare `uv sync --locked` without `--all-extras --all-groups` (dep-rank has zero optional extras and one `dev` dep-group which is auto-installed; the extra flags would be no-ops today).
- Default `python-version: "3.11"` (matches the hardcoded value previously in `publish.yml`).

## Known temporary regression

Once this merges, `uv sync --locked` is enforced on every PR. Dependabot does not update `uv.lock` when bumping `pyproject.toml`, so Dependabot PRs opened before issue #41 (lockfile auto-updater) lands will fail CI at the "Sync dependencies (locked)" step.

This is intentional — silent drift is exactly what `--locked` exists to catch. Mitigation during the rollout window: anyone with push access runs `uv lock && git commit uv.lock && git push` on the affected Dependabot branch. Should be a 30-second manual fix at most, maybe once or twice before #41 merges.

## Test plan

- [ ] CI matrix (`ci.yml`) passes green on all 9 cells (3 OSes × 3 Python versions)
- [ ] Nested step names `Setup uv > Install uv` and `Setup uv > Sync dependencies (locked)` appear in the job log (cosmetic confirmation)
- [ ] On rerun, at least one matrix cell log shows "Cache restored successfully" (advisory — proves cache-dependency-glob is wired)
- [x] Local `uv sync --locked && uv build` produces wheel + sdist (standing in for publish.yml's tag-gated build job, which cannot be triggered from the PR)

Fixes #34
See also: #38 (depends on this), #41 (should land close behind — closes the Dependabot regression window), #44 (rename `publish.yml` → `release.yml`; should land after this to avoid file-rename merge conflict)
