### PR TITLE
chore(ci): add cooldown-rescan caller (PR 2 of 2 for #40)

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -1,0 +1,23 @@
+name: Dependency Cool-Down Rescan
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "If true, log decisions but skip gh run rerun"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+  actions: write
+  statuses: read
+
+jobs:
+  rescan:
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
+    with:
+      dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dependency-cooldown-rescan.yml` as a thin wrapper around `j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@v2.5.2`. This is **PR 2 of 2** for issue #40 — it lands **first** as inert plumbing, then PR 1 (gate rename + inline scan delete) lands second.

## Why this PR is inert on its own

The shared `cooldown-rescan.yml` finds the prior gate run for each pending Dependabot PR by hardcoded path: `--workflow=.github/workflows/dependency-cooldown.yml`. Until PR 1 renames `dependency-cooldown-gate.yml` → `dependency-cooldown.yml`, this lookup returns nothing and every PR is logged as `Action: skip | no-prior-run`. That is the expected behavior; not a defect.

## Verification

Pre-merge (local):
- [x] YAML parses (`uv run --with pyyaml python -c "import yaml; yaml.safe_load(...)"`)
- [x] SHA pin matches `gh api repos/j7an/shared-workflows/commits/v2.5.2 --jq .sha` → `365119edbe2b1c7339d7727d9e8d021784e5bc01`
- [x] `cooldown-rescan.yml@v2.5.2` confirmed to accept `dry_run` boolean input

Post-merge (run after this PR is merged):
\`\`\`bash
gh workflow run dependency-cooldown-rescan.yml --ref main -f dry_run=true
\`\`\`
Filter to \`--event workflow_dispatch\` when watching the run. Assert: run conclusion \`success\`; step summary table renders. Open Dependabot PRs (if any) will show \`Action: skip | no-prior-run\` — see "Why this PR is inert" above.

## Explicitly NOT verified pre-merge

- Live cron at 06:17 UTC — exercises itself within 24 hours of merge.
- Bot-path scan/rerun behavior — requires PR 1 to land first AND a real Dependabot PR to exist.