### PR TITLE
ci: add Zizmor scanner and remove unnecessary CodeQL autobuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: ./.github/actions/setup-uv
         with:
           python-version: ${{ matrix.python-version }}
@@ -47,7 +47,7 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Dependency Review
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,9 +38,6 @@ jobs:
           languages: python
           queries: +security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,15 +14,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+permissions: {}
 
 jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -46,6 +47,8 @@ jobs:
   trufflehog:
     name: TruffleHog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -76,6 +79,9 @@ jobs:
   zizmor:
     name: Zizmor
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -97,6 +103,9 @@ jobs:
   trivy:
     name: Trivy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
@@ -131,6 +140,10 @@ jobs:
   osv-scan:
     name: OSV-Scanner
     if: github.event_name == 'push' || github.event_name == 'schedule'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     with:
       scan-args: --recursive ./
@@ -138,6 +151,10 @@ jobs:
   osv-scan-pr:
     name: OSV-Scanner PR
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     with:
       scan-args: --recursive ./

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,6 +73,27 @@ jobs:
           echo "::error::TruffleHog detected verified secrets. Review the scan output above."
           exit 1
 
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          version: "1.24.1"
+          min-severity: medium
+          min-confidence: medium
+
   trivy:
     name: Trivy
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
@@ -53,7 +53,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -104,7 +104,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate SARIF report
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0


### PR DESCRIPTION
## Summary

- Adds a new `zizmor` job to `.github/workflows/security.yml` running `zizmor-action@v0.5.3` in default SARIF-to-Code-scanning mode (`advanced-security: true`). Job exits 0 on findings; alerts publish to the Security tab under category `zizmor`.
- Removes the no-op CodeQL `Autobuild` step (Python doesn't need it; CodeQL indexes `.py` sources directly during `init`). Saves ~10s per run.
- **Commit 3 (post-CI scope expansion):** corrects 5 stale `# v5` comments on `actions/checkout@de0fac2e...` SHAs (the SHA actually points to v6.0.2, verified via `gh api repos/actions/checkout/commits/v6.0.2`). Surfaced by zizmor's `ref-version-mismatch` audit on the first CI run. The spec and plan for #37 had explicitly deferred these comment fixes ("track as a separate one-line PR if desired" / "could ride along with that PR" — referring to #36's eventual PR, not this one), so this is **post-run scope expansion authorized at PR-review time, not originally-authorized scope.** The fix is 5 character-pattern replacements with the SHAs already correct, so it was lower-risk to fix in-place than to rebase or open a separate PR.
- **Commit 4 (post-review scope expansion):** scopes `security-events: write` to per-job permissions in `security.yml`, replacing the broad workflow-level grant. Resolves the `excessive-permissions` Zizmor alert that the original plan deferred to follow-up issue #51. Pulled into this PR after PR review flagged sequencing concerns with auto-closing #37 while alerts remained open. After Commit 4 lands in CI, alert #42 (`excessive-permissions`) auto-resolves; only the two `dependabot-cooldown` alerts remain. Note: #51's description listed `osv-scan` / `osv-scan-pr` as not needing `security-events: write`, but the Google OSV-scanner reusable workflows declare and need it (verified via `code-scanning/analyses` API). The implementation grants it correctly per-job to those callers.

Closes #37
Fixes #51

## Triage of known initial findings

After Commit 4, the live alerts on `refs/pull/52/merge` reduce to **2 (was 3)**. Disposition:

| # | Audit | Location | Confidence | Disposition |
|---|---|---|---|---|
| 1 | `dependabot-cooldown` | `.github/dependabot.yml` (`uv` ecosystem) | High | **Dismiss "Won't fix":** dep-rank uses a workflow-based cooldown approach per the active design at `docs/superpowers/specs/2026-04-24-cooldown-shared-workflow-migration-design.md`. Native `dependabot.yml` cooldown is an explicit non-goal of that design. |
| 2 | `dependabot-cooldown` | `.github/dependabot.yml` (`github-actions` ecosystem) | High | **Dismiss "Won't fix":** same as #1. |
| 3 | `excessive-permissions` | `.github/workflows/security.yml` (workflow-level `security-events: write`) | High | **Resolved by Commit 4 in this PR.** Auto-resolves on next CI run because the workflow-level grant is gone; per-job permissions take its place. Issue #51 closes via `Fixes #51`. |

**Triage history:**
- First CI run (pre-Commit 3): 8 alerts — these 3 plus 5 `ref-version-mismatch` findings on stale `# v5` comments.
- After Commit 3: 3 alerts (the 5 ref-version-mismatch findings cleared).
- After Commit 4 (this CI run): expected 2 alerts (the `excessive-permissions` finding clears).

## Test plan

- [x] All four pinned action SHAs verified via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` (see commit messages).
- [x] Local `zizmor==1.24.1 --min-severity medium --min-confidence medium .github/` after Commit 4 reports only the 2 `dependabot-cooldown` findings (note: local can miss `ref-version-mismatch` without `GH_TOKEN`; CI catches them).
- [x] `pre-commit run --files .github/workflows/security.yml` is green locally.
- [ ] On this PR's latest CI run (post-Commit 4):
  - [ ] `Zizmor` job is **green** (exits 0; SARIF upload mode).
  - [ ] `CodeQL` job still passes (`init` → `analyze` without Autobuild) under per-job permissions.
  - [ ] `TruffleHog`, `Trivy`, `OSV-Scanner PR` all unaffected by the per-job permissions refactor.
  - [ ] `excessive-permissions` alert (#42) auto-resolves; SARIF analyses API on `refs/pull/52/merge` reports `results_count: 2`.
- [ ] Post-merge: 2 `dependabot-cooldown` alerts dismissed in the Security tab UI as "Won't fix" with the rationale above. Alert #42 should already be auto-resolved by GitHub when the next analysis no longer reports it.

## Notes on scope vs. spec

The original spec (`docs/superpowers/specs/2026-04-24-zizmor-codeql-cleanup-design.md`) and plan (`docs/superpowers/plans/2026-04-24-zizmor-codeql-cleanup.md`) targeted a single-file change to `security.yml` (Autobuild removal + Zizmor job insertion). Commits 3 and 4 expanded scope after the original spec was written:

- **Commit 3** (`ci.yml` + 3 sites in `security.yml`): addresses CI-surfaced `ref-version-mismatch` findings. Originally deferred to a separate PR.
- **Commit 4** (per-job permissions in `security.yml`): addresses the spec's deferred `excessive-permissions` finding. Originally tracked in follow-up issue #51.

Both expansions are documented here rather than retroactively edited into the spec/plan. They were authorized at PR-review time, not at design time.

## Out of scope (still deferred)

- Hard-blocking PR gate on Zizmor findings (would require `advanced-security: false` + branch protection — separate decision).
- Bumping `harden-runner` SHA from v2.16.0 to v2.17.0 in the `codeql`, `trufflehog`, and `trivy` jobs. Dependabot's group-bump will handle this.
- Migrating CodeQL queries from `security-and-quality` to `security-extended`.
