### PR TITLE
chore(ci): bump pinned action SHAs (harden-runner v2.17.0, TruffleHog v3.94.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
       - name: Checkout code

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 
@@ -51,7 +51,7 @@ jobs:
       contents: read
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 
@@ -108,7 +108,7 @@ jobs:
       security-events: write
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: TruffleHog secret scan
         id: trufflehog
-        uses: trufflesecurity/trufflehog@586f66d7886cd0b037c7c245d4a6e34ef357ab10 # v3.94.1
+        uses: trufflesecurity/trufflehog@47e7b7cd74f578e1e3145d48f669f22fd1330ca6 # v3.94.3
         continue-on-error: true
         with:
           path: ./


### PR DESCRIPTION
## Summary

- Bumps `step-security/harden-runner` from v2.16.0 → v2.17.0 across `ci.yml` (2 sites) and `security.yml` (3 sites)
- Bumps `trufflesecurity/trufflehog` from v3.94.1 → v3.94.3 in `security.yml` (1 site)
- Out of scope: `publish.yml` (already on v2.17.0), and the caller workflows `tag-release.yml` / `dependency-cooldown.yml` / `dependency-cooldown-rescan.yml` (no direct harden-runner pin — delegate to `j7an/shared-workflows@v2.5.2`)

## Test plan

- [x] Pre-change `gh api` checks confirmed target SHAs are commit SHAs (not annotated tag refs)
- [x] Post-change invariant grep returns empty for both `step-security/harden-runner@` and `trufflesecurity/trufflehog@`
- [x] Supplementary count checks pass: `ci.yml`: 2 / `security.yml`: 4 (3 newly bumped + 1 already at v2.17.0 from PR #52) / `security.yml` TruffleHog: 1
- [ ] CI on this PR: `ci.yml`, `security.yml`, and `Dependency Cool-Down` caller all pass

## Merge note

Two-commit history is intentional (per [spec](docs/superpowers/specs/2026-04-25-bump-pinned-action-shas-design.md), it enables surgical revert of either action independently). If the repo's default merge strategy is squash, please consider a merge commit instead — but this is a recommendation, not a blocker, and either merge style satisfies the issue's acceptance criteria.

## Known transient drift

The three reusable-workflow callers (`tag-release.yml`, `dependency-cooldown.yml`, `dependency-cooldown-rescan.yml`) delegate to `j7an/shared-workflows@v2.5.2`, which still pins `step-security/harden-runner@v2.16.0` internally. So at runtime, those three workflows still execute the old harden-runner pin even after this PR merges.

This will self-heal automatically:
1. Upstream `j7an/shared-workflows` Dependabot (weekly, 7-day cooldown) will bump harden-runner there.
2. A new `shared-workflows` release will follow.
3. dep-rank's own Dependabot (weekly, `github-actions` ecosystem) will open a PR bumping the `@v2.5.2` reusable-workflow pin.
4. `dependency-cooldown.yml` will auto-merge that PR after its 5-day cooldown.

No follow-up issue is filed because both Dependabot configurations are already in place and the cool-down auto-merge is enabled — tracking work that's on autopilot would be process noise.

Closes #36