### PR TITLE
ci: split test job into parallel lint, typecheck, test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,36 @@ concurrency:
 permissions: {}
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv
+      - name: Ruff format check
+        run: uv run ruff format --check src/ tests/
+      - name: Ruff check
+        run: uv run ruff check src/ tests/
+
+  typecheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv
+      - name: Mypy
+        run: uv run mypy src/dep_rank/
+
   test:
     strategy:
       fail-fast: false
@@ -26,14 +56,12 @@ jobs:
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-uv
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv run ruff format --check src/ tests/
-      - run: uv run ruff check src/ tests/
-      - run: uv run mypy src/dep_rank/
-      - run: uv run pytest
+      - name: Pytest
+        run: uv run pytest
 
   dependency-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Split the monolithic `test` job into three parallel jobs: `lint` (ruff format + check), `typecheck` (mypy), `test` (pytest).
- `lint` and `typecheck` run once on `ubuntu-latest` with composite `setup-uv` default Python 3.11 (matches `[tool.ruff] target-version = "py311"` and `[tool.mypy] python_version = "3.11"`).
- `test` retains the existing 3 OS × 3 Python matrix unchanged. All matrix cells now run only `pytest` — saves 8 redundant lint/typecheck runs per PR.
- `dependency-review` job unchanged.

Closes #38.

## Spec

`docs/superpowers/specs/2026-04-25-ci-split-lint-typecheck-test-design.md` (local, gitignored).

## Pre-merge coordination

The `Protect main` ruleset (id `14481627`) must be updated to require the new `lint` and `typecheck` status-check contexts BEFORE this PR is merged. Without that update, lint/typecheck failures on subsequent PRs would not block merges. See spec section "Pre-merge ruleset coordination" for the `gh api` script.

## Test plan

- [ ] CI passes on this PR — `lint`, `typecheck`, and `test (<os>, <py>)` x 9 all green
- [ ] CI jobs ran in parallel (started within seconds of each other, not serially)
- [ ] Time-to-`lint`-result on this PR is noticeably faster than the old chained job's time-to-first-failure
- [ ] After ruleset edit, the PR's "Required" check list shows `lint`, `typecheck`, and the existing `test (...)` and `dependency-cooldown / gate` contexts