### PR TITLE
chore(ci): disable shared-workflow auto-merge in cooldown caller

### DIFF
--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -18,5 +18,5 @@ jobs:
   cooldown:
     uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
     with:
-      auto_merge: true
+      auto_merge: false
       cooldown_days: 5


### PR DESCRIPTION
## Summary

- Flip `auto_merge: true → false` in `.github/workflows/dependency-cooldown.yml`.
- Honors the saved no-auto-merge preference: every Dependabot PR — including those that pass the cooldown gate — requires explicit human merge.
- Adjacent prerequisite to issue #41; ships first to avoid briefly widening the auto-merge surface area when the issue-#41 PRs land.

## Test plan

- [ ] `actionlint` passed locally before push
- [ ] CI workflows (`lint`, `typecheck`, `test`, `dependency-cooldown / gate`) pass on this PR
- [ ] After merge, comment `@dependabot recreate` on PR #32 and verify cooldown gate clears without `dependabot[bot] merged this pull request` event in the timeline
- [ ] No regression in other PRs' cooldown behavior

## Spec

`docs/superpowers/specs/2026-04-25-disable-cooldown-auto-merge-design.md`