### PR TITLE
ci: scope Dependabot uv group to minor/patch with major-version ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,12 @@ updates:
       prefix: "deps"
       include: "scope"
     groups:
-      all-python:
-        patterns:
-          - "*"
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Rename Dependabot uv group `all-python` → `minor-and-patch`.
- Scope the group to `update-types: ["minor", "patch"]`.
- Add a top-level `ignore` block that filters `version-update:semver-major` for all dependencies.

This brings the uv ecosystem entry to parity with [`j7an/nexus-mcp`'s `dependabot.yml`](https://github.com/j7an/nexus-mcp/blob/main/.github/dependabot.yml). The next Dependabot uv PR should produce a rich body with version table, release notes, and changelogs (compare PR #32 today vs. nexus-mcp PR #170).

Partial implementation of issue #41 — this PR addresses subsystem 3 of 3 (uv group scoping). Subsystems 1 (lockfile auto-update) and 2 (pre-commit autoupdate) ship in subsequent PRs; #41 closes only with the lockfile PR.

## Escape hatches for the major-version ignore

If a legitimate major upgrade is needed (security-critical bump, etc.):

1. **Manual `pyproject.toml` bump** (canonical). Dependabot opens a follow-up PR for transitive lockfile churn under the new major.
2. **Temporarily narrow or remove** the `update-types: ignore` rule, let Dependabot open the major PR, then restore the ignore.

`allow:` rules **do not** override `ignore:` — Dependabot applies `allow` first and `ignore` second, so a dep matched by both is still filtered out.

## Test plan

- [ ] CI lint/typecheck/test pass on this PR
- [ ] Post-merge: Settings → Code security → Dependabot → "View errors" empty for uv ecosystem
- [ ] Post-merge: comment `@dependabot recreate` on PR #32 and verify the recreated PR consolidates per the new group spec and produces a rich body

## Spec

`docs/superpowers/specs/2026-04-25-issue-41-dependabot-automation-design.md` (§PR-A)