### PR TITLE
ci: add pre-commit autoupdate workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,55 @@
+name: Pre-commit Autoupdate
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"  # Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Install pre-commit
+        run: uv run pre-commit --version
+      - name: Run pre-commit autoupdate
+        run: uv run pre-commit autoupdate
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet .pre-commit-config.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: deps/pre-commit-autoupdate
+          title: "deps: update pre-commit hooks"
+          commit-message: "deps: update pre-commit hooks"
+          sign-commits: true
+          add-paths: .pre-commit-config.yaml
+          body: |
+            Automated update of pre-commit hook versions via `pre-commit autoupdate`.
+
+            Review the diff to verify hook version changes are expected.
+          labels: dependencies


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/pre-commit-autoupdate.yml` runs `pre-commit autoupdate` weekly (Monday 08:00 UTC) and on demand via `workflow_dispatch`.
- When `.pre-commit-config.yaml` changes, the workflow mints a short-lived installation token from the shared `Release Bot` GitHub App and opens a signed bot PR via `peter-evans/create-pull-request@v8.1.1` (`sign-commits: true`, `add-paths: .pre-commit-config.yaml`, label `dependencies`).
- Three intentional deltas vs. nexus-mcp's GITHUB_TOKEN form: (1) App-token authentication so the resulting bot PR triggers required workflow checks (PRs created via GITHUB_TOKEN don't); (2) `persist-credentials: false` on checkout to satisfy dep-rank's zizmor `artipacked` gate; (3) `add-paths` enforces the diff scope as a contract rather than an expectation.

Partial implementation of issue #41 — this PR addresses subsystem 2 of 3 (pre-commit autoupdate). #41 closes only with the lockfile auto-update PR.

## Why a GitHub App, not GITHUB_TOKEN

`peter-evans/create-pull-request` and the GitHub Actions docs both note that PRs created using `secrets.GITHUB_TOKEN` do NOT trigger new `pull_request` workflow runs (the only exceptions are `workflow_dispatch` and `repository_dispatch`). dep-rank's required-status-check posture (`lint`, `typecheck`, `test`, `dependency-cooldown / gate`) makes that mean: a bot PR opened with GITHUB_TOKEN sits with no checks running and is unmergeable through normal flow. App-token-authored PRs trigger workflows normally. The same App is used by PR-C's `update-lockfile` job — created once, used in two surfaces, with secrets in two vaults (Actions for PR-B; Dependabot for PR-C).

## One-time external setup (must be in place before merge)

- GitHub App `Release Bot` (App ID `3350193`, owned by `j7an`) installed on `j7an/dep-rank` with `Contents: Read & Write` and `Pull Requests: Write`. The App is reused from nexus-mcp; broaden permissions there if not already granted.
- Repo Variable (Settings → Secrets and variables → **Actions** tab → **Variables** sub-tab): `RELEASE_BOT_APP_ID = 3350193`. Variables are non-sensitive and readable from any workflow context (including Dependabot-triggered runs), so PR-C reads the same Variable without a duplicate.
- Actions secret (Settings → Secrets and variables → **Actions** tab → **Secrets** sub-tab): `RELEASE_BOT_PRIVATE_KEY` (PEM verbatim).
- If PR-C has already landed, the App, the Variable, and the Dependabot-vault PEM already exist — only the Actions-vault PEM needs to be added.

## Failure mode worth flagging in review

dep-rank's CI runs `ruff` and `mypy` directly, not via `pre-commit`. So a hook-version bump that breaks the pre-commit config will not surface as a red CI check on the bot PR — it surfaces only when a developer next runs `pre-commit run` locally. **The sole pre-merge safety net for this workflow's bot PRs is human review of the diff.** Keep that in mind when triaging the first few autoupdate PRs.

## Test plan

- [x] `actionlint` passed locally before push (dep-rank's `security.yml` runs zizmor/CodeQL/TruffleHog/Trivy/OSV but does NOT run actionlint — so the local pre-push run is the only static gate)
- [x] `zizmor --min-severity medium --min-confidence medium` passes locally (will also run via the security workflow's zizmor job after merge)
- [ ] Post-merge: `gh workflow run pre-commit-autoupdate.yml` succeeds (smoke test)
- [ ] Post-merge: if hook versions are already current, the run completes with no PR opened (diff guard short-circuits)
- [ ] Post-merge: if hook versions have drifted, a bot PR appears under branch `deps/pre-commit-autoupdate` authored by `Release Bot[bot]` with `dependencies` label, a signed commit, AND running `lint`/`typecheck`/`test`/`dependency-cooldown / gate` (the App-token-vs-GITHUB_TOKEN distinction is what makes this last item work)

## Spec

`docs/superpowers/specs/2026-04-25-issue-41-dependabot-automation-design.md` (§PR-B)