### PR TITLE
ci: add lockfile auto-update job for Dependabot Python PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,58 @@ concurrency:
 permissions: {}
 
 jobs:
+  update-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      committed: ${{ steps.commit.outputs.committed }}
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - run: uv lock
+      - name: Commit updated lockfile
+        id: commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if git diff --quiet uv.lock; then
+            echo "No lockfile changes"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CONTENT=$(base64 -w0 uv.lock)
+          HEAD_OID=$(git rev-parse HEAD)
+          gh api graphql -f query='
+            mutation($input: CreateCommitOnBranchInput!) {
+              createCommitOnBranch(input: $input) {
+                commit { url }
+              }
+            }
+          ' -f "input[branchRef][repositoryNameWithOwner]=${{ github.repository }}" \
+            -f "input[branchRef][branchName]=${{ github.head_ref }}" \
+            -f "input[expectedHeadOid]=${HEAD_OID}" \
+            -f "input[message][headline]=deps: update uv.lock" \
+            -f "input[fileChanges][additions][0][path]=uv.lock" \
+            -f "input[fileChanges][additions][0][contents]=${CONTENT}"
+          echo "committed=true" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: [update-lockfile]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,6 +73,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-uv
       - name: Ruff format check
         run: uv run ruff format --check src/ tests/
@@ -29,6 +83,8 @@ jobs:
         run: uv run ruff check src/ tests/
 
   typecheck:
+    needs: [update-lockfile]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,11 +94,16 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-uv
       - name: Mypy
         run: uv run mypy src/dep_rank/
 
   test:
+    needs: [update-lockfile]
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +118,9 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
+          persist-credentials: false
       - uses: ./.github/actions/setup-uv
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   update-lockfile:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       committed: ${{ steps.commit.outputs.committed }}
@@ -39,6 +39,8 @@ jobs:
         id: commit
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           if git diff --quiet uv.lock; then
             echo "No lockfile changes"
@@ -47,14 +49,15 @@ jobs:
           fi
           CONTENT=$(base64 -w0 uv.lock)
           HEAD_OID=$(git rev-parse HEAD)
+          # shellcheck disable=SC2016
           gh api graphql -f query='
             mutation($input: CreateCommitOnBranchInput!) {
               createCommitOnBranch(input: $input) {
                 commit { url }
               }
             }
-          ' -f "input[branchRef][repositoryNameWithOwner]=${{ github.repository }}" \
-            -f "input[branchRef][branchName]=${{ github.head_ref }}" \
+          ' -f "input[branchRef][repositoryNameWithOwner]=$REPOSITORY" \
+            -f "input[branchRef][branchName]=$HEAD_REF" \
             -f "input[expectedHeadOid]=${HEAD_OID}" \
             -f "input[message][headline]=deps: update uv.lock" \
             -f "input[fileChanges][additions][0][path]=uv.lock" \


### PR DESCRIPTION
## Summary

- New `update-lockfile` job in `.github/workflows/ci.yml` runs on Dependabot-authored PRs only, regenerates `uv.lock`, and (on drift) commits the result via the `createCommitOnBranch` GraphQL mutation under the shared `Release Bot` GitHub App identity.
- `lint`, `typecheck`, `test` now `needs: [update-lockfile]` with `if: ${{ !cancelled() }}` and a `ref:` override gated on `needs.update-lockfile.outputs.committed == 'true'`. The `if:` deliberately omits a `result != 'failure'` clause so downstream jobs RUN after upstream failure (skipped required checks pass branch protection — letting them run instead lets `uv sync --locked` fail and correctly block merge). The `ref:` override applies only when a new commit was actually pushed; the no-drift path keeps merge-ref testing.
- `dependency-review` is intentionally not chained to `update-lockfile` (operates on PR diff, doesn't read `uv.lock`).

## Why a GitHub App, not GITHUB_TOKEN

`pull_request` events triggered by `GITHUB_TOKEN`-authored writes produce approval-gated workflow runs — they don't fire required checks until a maintainer manually approves. dep-rank's required-status-check posture (`lint`, `typecheck`, `test (× 3 Pythons × ubuntu)`, `dependency-cooldown / gate`) makes that approval-gating equivalent to "every Dependabot PR needs a manual click before any check can run." App-token-authored writes are not approval-gated; downstream runs fire normally.

The `Protect main` ruleset enforces `required_signatures`, so a plain `git push` is not viable. `createCommitOnBranch` produces signed commits server-side under the App identity, which satisfies the rule.

## Security hardening (commit 2)

The first commit (`718c2fa`) added the job using the plan's verbatim YAML. zizmor v1.24.1 then surfaced two HIGH-severity findings on the new job, addressed in the second commit (`3ed916e`):

- **`template-injection`** on `${{ github.head_ref }}` interpolated directly into the `gh api graphql` shell command. PR branch names on Dependabot PRs are attacker-influenceable. Fix: pipe `head_ref` and `repository` through step `env:` (`HEAD_REF`, `REPOSITORY`) so shell expansion happens after quoting, per [GitHub's documented script-injection mitigation](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).
- **`bot-conditions`** on `github.actor == 'dependabot[bot]'`. Fix: gate on `github.event.pull_request.user.login == 'dependabot[bot]'` (the PR's original author, not impersonable by follow-up pushers). The `expectedHeadOid` race-check on the GraphQL mutation handles the "maintainer pushed after Dependabot" scenario by failing cleanly rather than clobbering.

Also added `# shellcheck disable=SC2016` for the (intentional) single-quoted GraphQL `$input` variable. After both commits: `actionlint` and `zizmor --min-severity medium --min-confidence medium` both pass clean.

## One-time external setup (must be in place before merge)

- GitHub App `Release Bot` (App ID `3350193`, owned by `j7an`) installed on `j7an/dep-rank` with `Contents: Read & Write` and `Pull Requests: Write` (the latter is for PR-B's autoupdate workflow that shares the App; PR-C's job uses only Contents).
- Repo Variable (Settings → Secrets and variables → **Actions** tab → **Variables** sub-tab): `RELEASE_BOT_APP_ID = 3350193`. Variables are non-sensitive and readable from any workflow context, including Dependabot-triggered runs — so PR-C reads this same Variable without a duplicate copy in the Dependabot vault.
- Dependabot secret (Settings → Secrets and variables → **Dependabot** tab, not Actions): `RELEASE_BOT_PRIVATE_KEY` (PEM verbatim).
- PR-B stores the same PEM in the Actions vault as `RELEASE_BOT_PRIVATE_KEY` (and PR-B's release-bootstrap step also stores it in the `release` environment) — see PR-B's plan. The Variable is shared across all three contexts.

The PEM is a Secret, not a Variable, because it is sensitive. Workflows triggered by Dependabot resolve only Dependabot secrets, so storing the PEM in the Actions vault alone would silently fail at runtime for this job.

## Test plan

- [ ] CI lint/typecheck/test pass on this PR (note: the new job is gated on `pull_request.user.login == dependabot[bot]`, so it skips on this human-authored PR — verifying the gate correctness)
- [ ] Required checks list does NOT include `update-lockfile` (verified pre-merge)
- [ ] Post-merge: comment `@dependabot recreate` on PR #32. The recreated PR should:
  - Show two commits: Dependabot's bump + a `Release Bot[bot]` commit titled `deps: update uv.lock` (only when there's lockfile drift)
  - Have `lint`, `typecheck`, `test` all running on the new head SHA, **not** approval-gated
  - Have `dependency-cooldown / gate` re-running on the new head SHA
- [ ] Post-merge negative test: open a non-Dependabot PR that touches `pyproject.toml` without updating `uv.lock`. The `update-lockfile` job must skip; the `test` job must fail on `uv sync --locked`.

## Spec

`docs/superpowers/specs/2026-04-25-issue-41-dependabot-automation-design.md` (§PR-C)

Fixes #41