### PR TITLE
fix(ci): allow AGPL-3.0 carve-out for trufflesecurity/trufflehog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,4 +149,5 @@ jobs:
         with:
           fail-on-severity: moderate
           deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0
+          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog
           comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

Adds a narrow `allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog` carve-out to the `dependency-review` job in `.github/workflows/ci.yml`. Future TruffleHog SHA bumps (manual or Dependabot) will no longer fail the AGPL-3.0 deny-list check, while the deny-list policy stays intact for non-action dependencies.

Closes #54.

## Pre-merge restructure (already completed before this PR was opened)

- [x] New tracking issue created for sub-fix 2 (Node 20 deprecation on `actions/dependency-review-action`): #65
- [x] Issue #54 body edited to remove sub-fix 2 and the stale "re-run on PR #53" acceptance bullet (PR #53 merged 2026-04-25)

## Sub-fix 2 cross-reference

Sub-fix 2 (Node 20 deprecation) is tracked under #65 with hard deadlines:

- **2026-06-02** — GitHub forces Node 24 as the default Actions runtime
- **2026-09-16** — Node 20 fully removed from runners; `dependency-review` would hard-fail without the bump

As of this PR, no Node 24 release of `actions/dependency-review-action` exists upstream — the bump remains upstream-blocked.

## On the choice of `deny-licenses` (deprecated)

The carve-out is added to the `deny-licenses` input, which the upstream README marks as deprecated for possible removal in the next major release (tracking: actions/dependency-review-action#938). This is a deliberate tactical holdover — migrating to `allow-licenses` requires enumerating every license used by the repo's full dependency graph and is the right shape for a separate, larger design once upstream's migration guidance stabilizes.

## Test plan

- [ ] **Gate 1 (this PR):** `dependency-review` job is green on this PR's own CI run.
- [ ] **Gate 2 (post-merge, observed):** the next Dependabot-generated `trufflesecurity/trufflehog` SHA bump shows ✅ on `dependency-review` instead of failing on AGPL-3.0.
- [ ] **Gate 3 (post-merge, one-shot):** a synthetic draft PR adding a known AGPL-3.0 PyPI package to `pyproject.toml` triggers `dependency-review` failure citing the *Python* package (proves the deny-list still bites for non-action deps); the draft PR is closed without merging.

## References

- Spec: `docs/superpowers/specs/2026-04-27-issue-54-dependency-review-license-carveout-design.md` (local, not committed)
- Surfacing PR (already merged): #53
- purl spec: https://github.com/package-url/purl-spec
