### PR TITLE
fix(ci): canonicalize trivy-action version comments to satisfy zizmor

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Generate SARIF report
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: repo
           format: sarif
@@ -130,7 +130,7 @@ jobs:
           category: trivy
 
       - name: Fail on CRITICAL/HIGH vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: repo
           format: table


### PR DESCRIPTION
## Summary

- Canonicalizes the trailing version comments on the two `aquasecurity/trivy-action` SHA pins in `.github/workflows/security.yml` from `# 0.35.0` (bare numeric, no real upstream tag) to `# v0.35.0` (canonical, matches the upstream `v0.35.0` tag pointing at the pinned commit).
- Clears the recurrence trap that caused `zizmor/ref-version-mismatch` findings on PR #61 (where Dependabot inherited the bare-numeric style and produced `# 0.36.0`).
- **No SHA pin changes.** The pinned commit `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` is unchanged on both lines.

Closes #64

## Test plan

- [ ] Diff contains only two character-level `v` insertions (lines 119, 133); SHA unchanged
- [ ] zizmor CI job reports zero new `ref-version-mismatch` findings on `security.yml`
- [ ] All other CI jobs green