### PR TITLE
chore(release): rename publish.yml → release.yml and document RELEASE_BOT_APP_ID prereq

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish
+name: Release
 
 on:
   push:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,8 @@ These are already configured. Verify once if something seems broken:
 - [ ] Both environments use OIDC — no API tokens needed
 - [ ] `Release Bot` GitHub App installed on this repo (needed to push signed
   tags; bypasses the recursion guard that blocks `GITHUB_TOKEN` tag pushes)
+- [ ] `RELEASE_BOT_APP_ID` repository variable set
+  (Settings → Secrets and variables → Actions → Variables tab)
 - [ ] `RELEASE_BOT_PRIVATE_KEY` secret stored at repo level
   (Settings → Secrets and variables → Actions → Repository secrets)
 
@@ -31,7 +33,7 @@ These are already configured. Verify once if something seems broken:
 3. Click **Run workflow**. The shared `tag-release.yml` reusable workflow
    computes the next version, creates and pushes a signed `vX.Y.Z` tag
    via the Release Bot App
-4. The `v*` tag push triggers `publish.yml` (test → build → TestPyPI →
+4. The `v*` tag push triggers `release.yml` (test → build → TestPyPI →
    PyPI → GitHub Release)
 
 The "auto" bump analyzer reads commit subjects since the last tag, so
@@ -42,7 +44,7 @@ otherwise-`fix:` PR will flip a patch release to minor.
 ### Pre-release (manual tag push)
 
 The UI only offers `auto/patch/minor/major`, so pre-releases use a manual
-tag push. The same `publish.yml` runs and the classifier flags the release
+tag push. The same `release.yml` runs and the classifier flags the release
 as prerelease automatically:
 
     git checkout main && git pull origin main
@@ -55,7 +57,7 @@ Use **PEP 440 canonical** forms (no hyphens): `a1` / `b1` / `rc1` / `.dev1`.
 
 ## What Happens Next (Automated)
 
-The `publish.yml` workflow runs five jobs in sequence:
+The `release.yml` workflow runs five jobs in sequence:
 
 | Job | What it does |
 |-----|--------------|


### PR DESCRIPTION
## Summary

- Renames `.github/workflows/publish.yml` → `.github/workflows/release.yml` and updates the `name:` field to `Release`.
- Adds a missing `RELEASE_BOT_APP_ID` Prerequisites bullet to `RELEASE.md`.
- Updates three `publish.yml` references in `RELEASE.md` to `release.yml`.

Implements the code-PR portion of [issue #44](https://github.com/j7an/dep-rank/issues/44). The operational runbook (Trusted Publishers, GitHub environments, inaugural `v0.1.0` tag push, pipeline monitoring) follows in subsequent maintainer steps and is tracked in issue #44 itself.

## Intentional descopes vs issue #44

- **`release` environment + main-only branch policy**: descoped. Three workflows consume `RELEASE_BOT_PRIVATE_KEY` with distinct trust profiles; a naive main-only env breaks `ci.yml` and `pre-commit-autoupdate.yml`. Tracked in follow-up issue (filed after this PR merges).
- **Move/deduplicate `RELEASE_BOT_PRIVATE_KEY`**: descoped. Secret currently exists in three separately stored copies (Actions store, Dependabot store, `release` env), seeded together on 2026-04-27 with identical values; consolidation is part of the follow-up.
- **5-min wait timer on `pypi` env**: omitted. Reviewer gate is the substantive control; reversible 30-second config if `v0.1.0` experience suggests it would help.

The full descope analysis lives on issue #44 (this PR's tracking issue) — see the closure note that will be posted there. Issue #44's body itself will be narrowed (via `gh issue edit`) to match the post-descope contract before closure, so the unticked rows do not misrepresent shipped scope.

## Test plan

- [x] CI workflows pass on this branch (no behavior changes; YAML structure preserved)
- [ ] Post-merge: maintainer executes operational runbook (issue #44 Steps 2-11)
- [ ] Post-merge: `git tag v0.1.0 && git push origin v0.1.0` triggers the renamed `release.yml` workflow successfully