### PR TITLE
chore: align worktree gitignore entry with Superpowers convention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ dist/
 *.pyc
 .vscode
 docs/
-.worktree/
+.worktrees/
 src/dep_rank/_version.py
 coverage.xml


### PR DESCRIPTION
## Summary
- Renames the gitignore entry for the worktree directory from `.worktree/` (singular) to `.worktrees/` (plural) to match the convention used by the Superpowers `using-git-worktrees` skill.
- The skill's directory resolution checks for `.worktrees` (preferred) and `worktrees` only — the singular form would force fall-through to a CLAUDE.md grep for detection rather than direct `ls` discovery, and the skill's `git check-ignore` safety verification would also miss it.

## Test plan
- [x] `.gitignore` diff is a single-line rename, no other changes
- [x] Branch created from `origin/main`, ahead 1
- [ ] After merge, future `git worktree add` invocations should target `.worktrees/<branch>` per the new convention