### PR TITLE
ci(deps): bump j7an/shared-workflows from v2.5.2 to v2.5.3

### DIFF
--- a/.github/workflows/dependency-cooldown-rescan.yml
+++ b/.github/workflows/dependency-cooldown-rescan.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   rescan:
-    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
+    uses: j7an/shared-workflows/.github/workflows/cooldown-rescan.yml@f59942427bc49f29363f889f1365a77303f5a76f # v2.5.3
     with:
       dry_run: ${{ inputs.dry_run || false }}

--- a/.github/workflows/dependency-cooldown.yml
+++ b/.github/workflows/dependency-cooldown.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   cooldown:
-    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-cooldown.yml@f59942427bc49f29363f889f1365a77303f5a76f # v2.5.3
     with:
       auto_merge: true
       cooldown_days: 5

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@365119edbe2b1c7339d7727d9e8d021784e5bc01 # v2.5.2
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@f59942427bc49f29363f889f1365a77303f5a76f # v2.5.3
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
Bumps the pinned `j7an/shared-workflows` reusable-workflow references from
v2.5.2 to v2.5.3 across all three consuming workflow files
(`tag-release.yml`, `dependency-cooldown.yml`, `dependency-cooldown-rescan.yml`).

Pin moved by commit SHA (v2.5.3 is an annotated tag; the commit SHA is
`f59942427bc49f29363f889f1365a77303f5a76f`).

**Upstream changes in v2.5.3:**
- deps: bump step-security/harden-runner 2.16.0 to 2.19.1
- fix(tag-release): use Git Data API so commits and tags auto-sign

Changelog: https://github.com/j7an/shared-workflows/compare/v2.5.2...v2.5.3

No issue is being resolved by this PR.