### PR TITLE
build(deps): configure uv exclude-newer one-week cooldown (#98)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,13 @@ dev = [
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
+[tool.uv]
+exclude-newer = "1 week"
+# Exempt starlette so PYSEC-2026-161 fix (1.0.1, released within the cooldown
+# window) isn't reverted; remove this override once the advisory is older than
+# the global cooldown.
+exclude-newer-package = { starlette = "2030-01-01T00:00:00Z" }
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/dep_rank"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,13 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+starlette = "2030-01-01T00:00:00Z"
+
 [[package]]
 name = "aiofile"
 version = "3.9.0"


### PR DESCRIPTION
## Summary
- Adds `[tool.uv] exclude-newer = "1 week"` to `pyproject.toml` so registry-resolved dependencies must be at least seven days old. Reduces the chance of pulling in a broken or compromised release before the ecosystem has had time to catch it.
- Re-runs `uv lock`; the lockfile gains an `[options]` block recording the cutoff but no package versions change.
- Carves out a single per-package exemption for `starlette` so the **PYSEC-2026-161** fix landed in #97 (uploaded 4 days ago, inside the cooldown window) is not silently reverted. The override is dated `2030-01-01` so it acts as "no cooldown for starlette"; remove it once the 1.0.1 release ages past the global cutoff.

## Why the starlette exemption
Without it, `uv lock` resolves `starlette` back to **1.0.0**, reintroducing PYSEC-2026-161. OSV-Scanner (`fail-on-vuln: true`) would block the PR. The issue itself anticipates this: "Use `exclude-newer-package` only if a specific package needs an exception." A security advisory under cooldown qualifies.

## Verification
- `uv lock` — resolves cleanly.
- `uv sync --locked` — clean.
- `uv run ruff check .` — all checks passed.
- `uv run mypy src` — no issues in 15 source files.
- `uv run pytest --no-cov -q` — 128 passed.

## Test plan
- [ ] CI green (ruff, mypy, pytest, OSV-Scanner).
- [ ] Lockfile diff is surgical: only the new `[options]` block; no package version changes.
- [ ] Confirm `starlette == 1.0.1` in `uv.lock` after merge.

Fixes #98.
