### PR TITLE
fix(tests): clear DEP_RANK_TOKEN in clean_env fixture

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -56,7 +56,7 @@ Tests are organized into three packages mirroring the `src/dep_rank/` layout. Th
 
 ### Defined in `tests/conftest.py`
 
-- **`clean_env`** (autouse): Snapshots `DEP_RANK_TOKEN` before each test and restores it after, so tests that set or unset the token do not leak state across the suite.
+- **`clean_env`** (autouse): Removes `DEP_RANK_TOKEN` from the environment before each test and restores its original value (if any) after, so a token exported in the developer's shell does not leak into tests and tests that set or unset the token do not leak state across the suite. Its regression guard lives in `tests/test_conftest.py`.
 
 Module-level HTML constants are also defined in `conftest.py` and imported directly by `tests/core/test_scraper.py`:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 
 import pytest
 
@@ -174,15 +175,32 @@ DEPENDENTS_HTML_WITH_COUNTS = """
 """
 
 
+@contextlib.contextmanager
+def isolated_dep_rank_token() -> Iterator[None]:
+    """Remove ``DEP_RANK_TOKEN`` for the duration of the block, then restore it.
+
+    ``pop`` (not ``get``) is used so the variable is actually removed from the
+    environment, regardless of whether the developer has it exported in their
+    shell. On exit the variable is unconditionally cleared first — a block may
+    have set it even when it was absent originally, and that value must not
+    outlive the block — then the original value, if any, is restored. See
+    issue #70.
+    """
+    original = os.environ.pop("DEP_RANK_TOKEN", None)
+    try:
+        yield
+    finally:
+        os.environ.pop("DEP_RANK_TOKEN", None)
+        if original is not None:
+            os.environ["DEP_RANK_TOKEN"] = original
+
+
 @pytest.fixture(autouse=True)
 def clean_env() -> Generator[None, None, None]:
     """Ensure DEP_RANK_TOKEN is not leaked between tests.
 
-    Uses ``pop`` (not ``get``) so the variable is actually removed from the
-    environment for the duration of the test, regardless of whether the
-    developer has it exported in their shell. See issue #70.
+    Thin wrapper around :func:`isolated_dep_rank_token`; the logic lives there
+    so it can be exercised directly by ``tests/test_conftest.py``.
     """
-    original = os.environ.pop("DEP_RANK_TOKEN", None)
-    yield
-    if original is not None:
-        os.environ["DEP_RANK_TOKEN"] = original
+    with isolated_dep_rank_token():
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,10 +176,13 @@ DEPENDENTS_HTML_WITH_COUNTS = """
 
 @pytest.fixture(autouse=True)
 def clean_env() -> Generator[None, None, None]:
-    """Ensure DEP_RANK_TOKEN is not leaked between tests."""
-    original = os.environ.get("DEP_RANK_TOKEN")
+    """Ensure DEP_RANK_TOKEN is not leaked between tests.
+
+    Uses ``pop`` (not ``get``) so the variable is actually removed from the
+    environment for the duration of the test, regardless of whether the
+    developer has it exported in their shell. See issue #70.
+    """
+    original = os.environ.pop("DEP_RANK_TOKEN", None)
     yield
-    if original is None:
-        os.environ.pop("DEP_RANK_TOKEN", None)
-    else:
+    if original is not None:
         os.environ["DEP_RANK_TOKEN"] = original

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -5,10 +5,14 @@ snapshot (``os.environ.get``) that leaves ``DEP_RANK_TOKEN`` in the
 environment during the test body. See issue #70.
 """
 
+from __future__ import annotations
+
 import os
 from collections.abc import Generator
 
 import pytest
+
+from tests import conftest
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -42,3 +46,37 @@ def test_clean_env_clears_dep_rank_token() -> None:
     assertion, regardless of the developer's shell or CI environment.
     """
     assert os.environ.get("DEP_RANK_TOKEN") is None
+
+
+@pytest.mark.parametrize(
+    ("original", "set_in_body", "expected_after"),
+    [
+        # Absent originally, test body sets it -> teardown must clear it.
+        (None, "set-by-test", None),
+        # Present originally, test body changes it -> teardown restores original.
+        ("orig-token", "changed-by-test", "orig-token"),
+    ],
+)
+def test_clean_env_teardown_restores_environment(
+    original: str | None, set_in_body: str, expected_after: str | None
+) -> None:
+    """``clean_env`` teardown must restore the pre-test environment exactly.
+
+    A sibling test cannot observe teardown: the next test's autouse ``clean_env``
+    setup pops the variable before its body runs, masking any leak. So exercise
+    :func:`conftest.isolated_dep_rank_token` (the context manager ``clean_env``
+    delegates to) directly and inspect the environment after the block exits.
+    Guards the ``original is None`` teardown branch, which a naive
+    ``if original is not None: restore`` (no unconditional clear) would leave
+    leaking the test-set value.
+    """
+    if original is None:
+        os.environ.pop("DEP_RANK_TOKEN", None)
+    else:
+        os.environ["DEP_RANK_TOKEN"] = original
+
+    with conftest.isolated_dep_rank_token():
+        os.environ["DEP_RANK_TOKEN"] = set_in_body  # noqa: S105 (test value, not a real secret)
+
+    assert os.environ.get("DEP_RANK_TOKEN") == expected_after
+    os.environ.pop("DEP_RANK_TOKEN", None)  # leave env clean for the autouse fixture

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -1,0 +1,44 @@
+"""Regression tests for shared fixtures defined in ``tests/conftest.py``.
+
+Guards the ``clean_env`` autouse fixture against regressing to a read-only
+snapshot (``os.environ.get``) that leaves ``DEP_RANK_TOKEN`` in the
+environment during the test body. See issue #70.
+"""
+
+import os
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed_dep_rank_token() -> Generator[None, None, None]:
+    """Seed ``DEP_RANK_TOKEN`` before the function-scoped ``clean_env`` runs.
+
+    This MUST stay module-scoped. ``clean_env`` is a *function*-scoped autouse
+    fixture in the root ``conftest.py``; at equal scope, autouse fixtures from a
+    higher-level conftest instantiate before module-level ones, so a
+    function-scoped seed here would lose the ordering race and ``clean_env``
+    would clear the env before this ever set it. A higher (module) scope always
+    instantiates first, guaranteeing the token is present when ``clean_env``
+    runs. Do not "simplify" this to function scope — it silently disables the
+    guard below.
+    """
+    original = os.environ.get("DEP_RANK_TOKEN")
+    os.environ["DEP_RANK_TOKEN"] = "fixture-regression-sentinel"  # noqa: S105 (test sentinel, not a real secret)
+    yield
+    if original is None:
+        os.environ.pop("DEP_RANK_TOKEN", None)
+    else:
+        os.environ["DEP_RANK_TOKEN"] = original
+
+
+def test_clean_env_clears_dep_rank_token() -> None:
+    """``clean_env`` must remove ``DEP_RANK_TOKEN`` for the duration of a test.
+
+    With the seed fixture above guaranteeing the var is set going in, a correct
+    ``clean_env`` (using ``os.environ.pop``) leaves it absent here. A regression
+    to ``os.environ.get`` would leave the sentinel in place and fail this
+    assertion, regardless of the developer's shell or CI environment.
+    """
+    assert os.environ.get("DEP_RANK_TOKEN") is None


### PR DESCRIPTION
## What

Fixes the `clean_env` autouse fixture in `tests/conftest.py`, which read `DEP_RANK_TOKEN` with `os.environ.get` but never removed it before `yield`. A token exported in the developer's shell leaked into every test, so the missing-token assertions (`test_missing_token`, `test_deps_descriptions_without_token`) failed locally while passing in CI (where no token is exported).

## Changes

- **`tests/conftest.py`** — `os.environ.get` → `os.environ.pop` so the variable is actually removed for the test body. The save/clear/restore logic now lives in an `isolated_dep_rank_token` context manager that `clean_env` delegates to; on exit it **unconditionally pops** before restoring any original value.
- **`tests/test_conftest.py`** (new) — regression guards:
  - `test_clean_env_clears_dep_rank_token`: a **module-scoped** autouse fixture seeds `DEP_RANK_TOKEN` *before* the function-scoped `clean_env` runs, then asserts `clean_env` cleared it. The module scope is load-bearing: at equal scope, root-`conftest` autouse fixtures instantiate before module-level ones, so a function-scoped seed would lose the ordering race (a comment in the file warns against "simplifying" it).
  - `test_clean_env_teardown_restores_environment` (parametrized): exercises `isolated_dep_rank_token` directly and asserts teardown restores the pre-test state exactly — clears a value set when none existed originally, restores the original when one did.
- **`tests/README.md`** — reworded to say the var is *removed during* each test, not just snapshotted, and points at the guard.

## Why the guards are deterministic

A bare `assert os.environ.get("DEP_RANK_TOKEN") is None` would *not* catch a regression to `.get` when no token is exported (CI's normal state) — it would pass with the bug present. The seed fixture establishes the precondition itself, so the guard fires regardless of shell or CI state. Teardown can't be observed by a sibling test (the next test's autouse setup-pop masks any leak), so it's tested via the context manager directly.

## Review follow-up

A code review caught that the first cut of the teardown only restored when a token existed originally — a test body that set `DEP_RANK_TOKEN` when the outer env had none would leak its value past teardown (masked today by the autouse setup-pop, but a latent trap). Fixed via the unconditional pop + the dedicated teardown regression test.

## Verification

- New `clears` guard fails against the buggy `.get` fixture, passes after the fix.
- New `teardown` guard fails against an `if original is not None`-only teardown, passes after the unconditional pop.
- The two originally-failing tests: `2 passed` both with `DEP_RANK_TOKEN=anything` and with `env -u DEP_RANK_TOKEN`.
- Full suite with token exported (worst case): `131 passed`, coverage `91.39%` (> 90% gate).
- ruff, ruff format, and mypy all clean.

Fixes #70.
