### PR TITLE
feat: scraper hardening phase 1 — result contract + adaptive rate limiter

### DIFF
--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class DependentType(StrEnum):
@@ -13,6 +13,19 @@ class DependentType(StrEnum):
 
     REPOSITORY = "REPOSITORY"
     PACKAGE = "PACKAGE"
+
+
+class ScrapeReason(StrEnum):
+    """Why a scrape terminated short of exhausting all pages.
+
+    ``None`` (absence of a reason) means the scrape was complete. The invariant
+    ``complete == (reason is None)`` holds across ScrapeResult and DependentsResult.
+    """
+
+    MAX_PAGES_REACHED = "max_pages_reached"
+    TREND_CONVERGED = "trend_converged"
+    NETWORK_FAILURE = "network_failure"
+    RATE_LIMITED = "rate_limited"
 
 
 class Repository(BaseModel):
@@ -33,6 +46,16 @@ class ScrapeResult(BaseModel):
     max_pages: int
     estimated_total_pages: int
     estimated_total_dependents: int
+    complete: bool = True
+    reason: ScrapeReason | None = None
+    matched_count: int = 0
+
+    @model_validator(mode="after")
+    def _check_complete_reason_invariant(self) -> ScrapeResult:
+        if self.complete != (self.reason is None):
+            msg = "ScrapeResult invariant violated: complete must equal (reason is None)"
+            raise ValueError(msg)
+        return self
 
 
 class DependentsResult(BaseModel):

--- a/src/dep_rank/core/rate_limiter.py
+++ b/src/dep_rank/core/rate_limiter.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import random
 import time
+from collections.abc import Callable
 
 
 class TokenBucketRateLimiter:
@@ -71,3 +73,95 @@ class TokenBucketRateLimiter:
             self._tokens + elapsed * (self._rate / self._period),
         )
         self._last_refill = now
+
+
+# Rate budgets (requests per RATE_PERIOD seconds).
+AUTH_RATE = 60
+UNAUTH_RATE = 1
+RATE_PERIOD = 60.0
+RECOVERY_PERIOD = 60.0
+RETRY_BASE_SECONDS = 5
+RETRY_MAX_SECONDS = 120
+
+
+class AdaptiveRateLimiter:
+    """Token-bucket limiter with AIMD concurrency control and 429 backoff.
+
+    ``current_max_concurrency`` is an *advisory* AIMD bound. It is **not** consulted
+    by the serial foreground walk — that uses a fixed ``Semaphore(concurrency)``, and
+    pagination is intrinsically serial (page N's cursor needs page N-1's HTML). It
+    instead governs the 429 backoff sleep and the Phase 3 SWR background-refresh gate
+    (refresh suppressed at the floor of 1). Per-scrape by default; inject a shared
+    instance for process-wide budgeting across concurrent scrapes.
+    """
+
+    def __init__(
+        self,
+        rate: int,
+        period: float,
+        concurrency: int,
+        *,
+        jitter: bool = True,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._bucket = TokenBucketRateLimiter(rate, period)
+        self._ceiling = concurrency
+        self.current_max_concurrency = concurrency
+        self._backoff_attempt = 0
+        self._jitter = jitter
+        self._now = now
+        self._last_increase = now()
+
+    @classmethod
+    def for_token(
+        cls,
+        token: str | None,
+        concurrency: int = 3,
+        *,
+        jitter: bool = True,
+        now: Callable[[], float] = time.monotonic,
+    ) -> AdaptiveRateLimiter:
+        """Build a limiter sized for the auth mode: 60/min with a token, 1/min without."""
+        rate = AUTH_RATE if token else UNAUTH_RATE
+        return cls(rate, RATE_PERIOD, concurrency, jitter=jitter, now=now)
+
+    async def acquire(self) -> None:
+        """Blocking acquire for foreground fetches."""
+        await self._bucket.acquire()
+
+    def try_acquire(self, reserve: float = 0.0) -> bool:
+        """Non-blocking acquire for background (SWR) refreshes; see §3.
+
+        ``reserve`` is forwarded to the bucket so a background refresh leaves
+        headroom for foreground fetches (see ``TokenBucketRateLimiter.try_acquire``).
+        """
+        return self._bucket.try_acquire(reserve)
+
+    def tokens_available(self) -> float:
+        return self._bucket.tokens_available()
+
+    def note_429(self, retry_after: float | None = None) -> float:
+        """Record a 429: halve advisory concurrency, restart the recovery clock, and
+        return the seconds to sleep."""
+        self.current_max_concurrency = max(1, self.current_max_concurrency // 2)
+        # A 429 must restart the additive-recovery timer: otherwise, on a limiter that
+        # has lived longer than RECOVERY_PERIOD, the very next clean response would step
+        # concurrency back up immediately, defeating the multiplicative decrease (and
+        # the SWR `current_max_concurrency <= 1` suppression gate in §3).
+        self._last_increase = self._now()
+        exp = min(RETRY_BASE_SECONDS * (2**self._backoff_attempt), RETRY_MAX_SECONDS)
+        self._backoff_attempt += 1
+        delay = random.uniform(0, exp) if self._jitter else float(exp)  # noqa: S311
+        if retry_after is not None:
+            delay = max(delay, retry_after)
+        return delay
+
+    def note_success(self) -> None:
+        """Record a clean response: reset backoff; additively recover concurrency."""
+        self._backoff_attempt = 0
+        if (
+            self.current_max_concurrency < self._ceiling
+            and self._now() - self._last_increase >= RECOVERY_PERIOD
+        ):
+            self.current_max_concurrency += 1
+            self._last_increase = self._now()

--- a/src/dep_rank/core/rate_limiter.py
+++ b/src/dep_rank/core/rate_limiter.py
@@ -31,6 +31,38 @@ class TokenBucketRateLimiter:
                 self._refill()
             self._tokens -= 1.0
 
+    def try_acquire(self, reserve: float = 0.0) -> bool:
+        """Consume one token if at least ``1 + reserve`` are available now; never blocks.
+
+        Returns True and consumes one token when enough are available, else returns
+        False and consumes nothing. Used by background work that must yield to
+        foreground callers.
+
+        ``reserve`` lets a background caller leave headroom for the foreground: with
+        ``reserve=1`` a token is taken only when >=2 remain, so a foreground caller
+        still finds one waiting. Keeping the headroom check and the decrement in the
+        same synchronous call (rather than a separate ``tokens_available()`` read
+        elsewhere) means no other coroutine can run between them, avoiding a
+        check-then-consume race.
+
+        Refuses (returns False) when the bucket lock is held: a foreground caller
+        waiting in ``acquire()`` holds the lock across its ``await sleep`` for a
+        token, so a lockless decrement here could steal the token it is about to
+        claim. Checking ``self._lock.locked()`` makes background work yield instead.
+        """
+        if self._lock.locked():
+            return False
+        self._refill()
+        if self._tokens >= 1.0 + reserve:
+            self._tokens -= 1.0
+            return True
+        return False
+
+    def tokens_available(self) -> float:
+        """Return the number of whole/partial tokens currently in the bucket."""
+        self._refill()
+        return self._tokens
+
     def _refill(self) -> None:
         now = time.monotonic()
         elapsed = now - self._last_refill

--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -12,7 +12,7 @@ import aiohttp
 from selectolax.parser import HTMLParser
 
 from dep_rank.core.cache import SqliteCache
-from dep_rank.core.models import DependentType, Repository, ScrapeResult
+from dep_rank.core.models import DependentType, Repository, ScrapeReason, ScrapeResult
 from dep_rank.core.rate_limiter import TokenBucketRateLimiter
 from dep_rank.core.validation import validate_github_url
 
@@ -236,10 +236,9 @@ async def scrape_dependents(
     prefetch_task: asyncio.Task[tuple[str | None, str | None]] | None = None
     estimated_total_pages = 0
     estimated_total_dependents = 0
+    fetch_failed = False
 
     while current_url and page < max_pages:
-        page += 1
-
         # Check cache first
         html: str | None = None
         cache_hit = False
@@ -264,7 +263,10 @@ async def scrape_dependents(
                 )
 
             if html is None:
+                fetch_failed = True
                 break
+
+        page += 1
 
         if page == 1:
             counts = parse_dependent_counts(html)
@@ -309,6 +311,16 @@ async def scrape_dependents(
         except asyncio.CancelledError:
             pass  # Expected when scraping ends before prefetch completes
 
+    # Classify how the walk ended. `fetch_failed` is set only by the `html is None`
+    # break above; a clean exhaustion drops `current_url` to None, and hitting the cap
+    # leaves `current_url` pointing at an unfetched next page with `page == max_pages`.
+    if fetch_failed:
+        reason: ScrapeReason | None = ScrapeReason.NETWORK_FAILURE
+    elif current_url is not None and page >= max_pages:
+        reason = ScrapeReason.MAX_PAGES_REACHED
+    else:
+        reason = None
+
     all_repos.sort(key=lambda r: r.stars, reverse=True)
     return ScrapeResult(
         repos=all_repos,
@@ -316,4 +328,7 @@ async def scrape_dependents(
         max_pages=max_pages,
         estimated_total_pages=estimated_total_pages,
         estimated_total_dependents=estimated_total_dependents,
+        complete=reason is None,
+        reason=reason,
+        matched_count=len(all_repos),
     )

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+from pydantic import ValidationError
+
 from dep_rank.core.models import (
     CodeSearchHit,
     CodeSearchResult,
     DependentsResult,
     DependentType,
     Repository,
+    ScrapeReason,
     ScrapeResult,
 )
 
@@ -125,3 +129,90 @@ class TestCodeSearchResult:
         )
         assert result.searched_repos == 5
         assert result.hits[0].matches == 3
+
+
+class TestScrapeReason:
+    def test_values(self) -> None:
+        assert ScrapeReason.MAX_PAGES_REACHED.value == "max_pages_reached"
+        assert ScrapeReason.TREND_CONVERGED.value == "trend_converged"
+        assert ScrapeReason.NETWORK_FAILURE.value == "network_failure"
+        assert ScrapeReason.RATE_LIMITED.value == "rate_limited"
+
+
+class TestScrapeResultContractFields:
+    def test_defaults_are_complete(self) -> None:
+        result = ScrapeResult(
+            repos=[],
+            pages_scraped=0,
+            max_pages=200,
+            estimated_total_pages=0,
+            estimated_total_dependents=0,
+        )
+        assert result.complete is True
+        assert result.reason is None
+        assert result.matched_count == 0
+
+    def test_incomplete_with_reason(self) -> None:
+        result = ScrapeResult(
+            repos=[],
+            pages_scraped=200,
+            max_pages=200,
+            estimated_total_pages=500,
+            estimated_total_dependents=15000,
+            complete=False,
+            reason=ScrapeReason.MAX_PAGES_REACHED,
+            matched_count=4200,
+        )
+        assert result.complete is False
+        assert result.reason == "max_pages_reached"
+        assert result.matched_count == 4200
+
+    def test_complete_must_equal_reason_absence(self) -> None:
+        """The terminal contract enforces ``complete == (reason is None)``."""
+        # complete=True but a reason is set -> invalid.
+        with pytest.raises(ValidationError):
+            ScrapeResult(
+                repos=[],
+                pages_scraped=1,
+                max_pages=200,
+                estimated_total_pages=0,
+                estimated_total_dependents=0,
+                complete=True,
+                reason=ScrapeReason.RATE_LIMITED,
+            )
+        # complete=False but no reason -> invalid.
+        with pytest.raises(ValidationError):
+            ScrapeResult(
+                repos=[],
+                pages_scraped=1,
+                max_pages=200,
+                estimated_total_pages=0,
+                estimated_total_dependents=0,
+                complete=False,
+                reason=None,
+            )
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            ScrapeReason.MAX_PAGES_REACHED,
+            ScrapeReason.TREND_CONVERGED,
+            ScrapeReason.NETWORK_FAILURE,
+            ScrapeReason.RATE_LIMITED,
+        ],
+    )
+    def test_every_reason_marks_incomplete(self, reason: ScrapeReason) -> None:
+        """All four terminal reasons construct cleanly and satisfy the invariant
+        (issue #74 acceptance: every documented stop reason is representable)."""
+        result = ScrapeResult(
+            repos=[],
+            pages_scraped=1,
+            max_pages=200,
+            estimated_total_pages=0,
+            estimated_total_dependents=0,
+            complete=False,
+            reason=reason,
+            matched_count=0,
+        )
+        assert result.complete is False
+        assert result.reason == reason

--- a/tests/core/test_rate_limiter.py
+++ b/tests/core/test_rate_limiter.py
@@ -37,3 +37,44 @@ class TestTokenBucketRateLimiter:
         await limiter.acquire()
         elapsed = time.monotonic() - start
         assert elapsed < 0.1
+
+    def test_try_acquire_consumes_when_available(self) -> None:
+        limiter = TokenBucketRateLimiter(rate=2, period=60.0)
+        assert limiter.try_acquire() is True
+        assert limiter.try_acquire() is True
+
+    def test_try_acquire_returns_false_when_empty(self) -> None:
+        limiter = TokenBucketRateLimiter(rate=1, period=60.0)
+        assert limiter.try_acquire() is True
+        # bucket now empty; over a 60s period it will not refill within the test
+        assert limiter.try_acquire() is False
+
+    @pytest.mark.asyncio
+    async def test_try_acquire_refuses_while_lock_held(self) -> None:
+        """A foreground caller waiting in acquire() holds the lock across its sleep;
+        try_acquire must yield to it rather than steal the token it is about to claim."""
+        # rate=5 leaves tokens available, so the only thing that can refuse
+        # try_acquire is the held lock — simulating the window where a foreground
+        # caller is sleeping in acquire() and a lockless decrement would steal the
+        # token it is about to claim.
+        limiter = TokenBucketRateLimiter(rate=5, period=60.0)
+        async with limiter._lock:  # simulate a foreground caller holding the lock
+            assert limiter.try_acquire() is False
+        # once the lock is free, background may proceed
+        assert limiter.try_acquire() is True
+
+    def test_tokens_available_reports_remaining(self) -> None:
+        limiter = TokenBucketRateLimiter(rate=3, period=60.0)
+        assert limiter.tokens_available() == pytest.approx(3.0, abs=0.05)
+        limiter.try_acquire()
+        assert limiter.tokens_available() == pytest.approx(2.0, abs=0.05)
+
+    def test_try_acquire_reserve_leaves_headroom(self) -> None:
+        """``reserve`` makes a background caller leave tokens for the foreground."""
+        limiter = TokenBucketRateLimiter(rate=2, period=60.0)
+        # 2 tokens; reserve=2 requires >=3 to consume -> refuse, take nothing.
+        assert limiter.try_acquire(reserve=2) is False
+        assert limiter.tokens_available() == pytest.approx(2.0, abs=0.05)
+        # reserve=1 requires >=2 -> consume one, leaving ~1 for the foreground.
+        assert limiter.try_acquire(reserve=1) is True
+        assert limiter.tokens_available() == pytest.approx(1.0, abs=0.05)

--- a/tests/core/test_rate_limiter.py
+++ b/tests/core/test_rate_limiter.py
@@ -7,7 +7,12 @@ import time
 
 import pytest
 
-from dep_rank.core.rate_limiter import TokenBucketRateLimiter
+from dep_rank.core.rate_limiter import (
+    RETRY_BASE_SECONDS,
+    RETRY_MAX_SECONDS,
+    AdaptiveRateLimiter,
+    TokenBucketRateLimiter,
+)
 
 
 class TestTokenBucketRateLimiter:
@@ -78,3 +83,95 @@ class TestTokenBucketRateLimiter:
         # reserve=1 requires >=2 -> consume one, leaving ~1 for the foreground.
         assert limiter.try_acquire(reserve=1) is True
         assert limiter.tokens_available() == pytest.approx(1.0, abs=0.05)
+
+
+class TestAdaptiveRateLimiter:
+    def test_for_token_unauthenticated_is_one_per_minute(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token(None, concurrency=3)
+        # One token available immediately, none after (60s period won't refill in-test).
+        assert limiter.try_acquire() is True
+        assert limiter.try_acquire() is False
+
+    def test_for_token_authenticated_is_sixty_per_minute(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3)
+        # 60 tokens in the bucket: 60 immediate acquisitions succeed.
+        assert all(limiter.try_acquire() for _ in range(60))
+        assert limiter.try_acquire() is False
+
+    def test_note_429_halves_concurrency_floor_one(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=8, jitter=False)
+        assert limiter.current_max_concurrency == 8
+        limiter.note_429()
+        assert limiter.current_max_concurrency == 4
+        limiter.note_429()
+        assert limiter.current_max_concurrency == 2
+        limiter.note_429()
+        assert limiter.current_max_concurrency == 1
+        limiter.note_429()
+        assert limiter.current_max_concurrency == 1  # floor
+
+    def test_note_429_backoff_grows(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3, jitter=False)
+        d0 = limiter.note_429()
+        d1 = limiter.note_429()
+        assert d1 > d0  # exponential growth without jitter
+
+    def test_note_429_honors_retry_after(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3, jitter=False)
+        delay = limiter.note_429(retry_after=99.0)
+        assert delay >= 99.0
+
+    def test_note_429_backoff_caps_at_max(self) -> None:
+        """Exponential growth is clamped at RETRY_MAX_SECONDS."""
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3, jitter=False)
+        for _ in range(5):  # 5, 10, 20, 40, 80 — the next would overshoot the cap
+            limiter.note_429()
+        delay = limiter.note_429()  # 5 * 2**5 = 160, clamped to 120
+        assert delay == RETRY_MAX_SECONDS
+
+    def test_note_429_jitter_returns_in_range(self) -> None:
+        """With jitter, the first delay falls in [0, exp] where exp = base (attempt 0)."""
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3, jitter=True)
+        delay = limiter.note_429()
+        assert 0.0 <= delay <= RETRY_BASE_SECONDS
+
+    def test_note_success_recovers_after_recovery_period(self) -> None:
+        clock = {"t": 1000.0}
+        limiter = AdaptiveRateLimiter.for_token(
+            "ghp_x", concurrency=4, jitter=False, now=lambda: clock["t"]
+        )
+        limiter.note_429()  # -> 2
+        assert limiter.current_max_concurrency == 2
+        clock["t"] += 5.0
+        limiter.note_success()  # too soon; no increase
+        assert limiter.current_max_concurrency == 2
+        clock["t"] += 60.0
+        limiter.note_success()  # past recovery_period; +1
+        assert limiter.current_max_concurrency == 3
+
+    def test_429_restarts_recovery_clock(self) -> None:
+        """A 429 resets the recovery baseline: a clean response immediately after it
+        must NOT recover, even on a limiter that has lived past RECOVERY_PERIOD."""
+        clock = {"t": 1000.0}
+        limiter = AdaptiveRateLimiter.for_token(
+            "ghp_x", concurrency=4, jitter=False, now=lambda: clock["t"]
+        )
+        clock["t"] += 100.0  # idle well past RECOVERY_PERIOD before any 429
+        limiter.note_429()  # 4 -> 2, and restart the recovery clock at t=1100
+        assert limiter.current_max_concurrency == 2
+        limiter.note_success()  # immediate clean response; must NOT recover
+        assert limiter.current_max_concurrency == 2
+        clock["t"] += 60.0  # now a full recovery period has elapsed since the 429
+        limiter.note_success()
+        assert limiter.current_max_concurrency == 3
+
+    def test_tokens_available_delegates_to_bucket(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3)
+        assert limiter.tokens_available() == pytest.approx(60.0, abs=0.05)
+        limiter.try_acquire()
+        assert limiter.tokens_available() == pytest.approx(59.0, abs=0.05)
+
+    @pytest.mark.asyncio
+    async def test_acquire_delegates_to_bucket(self) -> None:
+        limiter = AdaptiveRateLimiter.for_token("ghp_x", concurrency=3)
+        await limiter.acquire()  # does not raise

--- a/tests/core/test_scraper.py
+++ b/tests/core/test_scraper.py
@@ -6,7 +6,7 @@ import pytest
 from aiohttp import ClientSession
 from aioresponses import aioresponses
 
-from dep_rank.core.models import DependentType, Repository, ScrapeResult
+from dep_rank.core.models import DependentType, Repository, ScrapeReason, ScrapeResult
 from dep_rank.core.scraper import parse_dependent_counts, parse_dependents_page, scrape_dependents
 from tests.conftest import (
     DEPENDENTS_HTML_LAST_PAGE,
@@ -224,6 +224,73 @@ class TestScrapeDependents:
         # 90 repos / 30 per page = 3 estimated total pages
         assert progress_calls[0] == (1, 3)
         assert progress_calls[1] == (2, 3)
+
+    @pytest.mark.asyncio
+    async def test_complete_scrape_sets_complete_true(self) -> None:
+        """A scrape that exhausts all pages reports complete=True, reason=None,
+        and matched_count equal to the number of repos that passed min_stars."""
+        async with ClientSession() as session:
+            with aioresponses() as m:
+                m.get(
+                    "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
+                    body=DEPENDENTS_HTML_LAST_PAGE,
+                )
+                result = await scrape_dependents(
+                    session,
+                    "https://github.com/owner/repo",
+                    min_stars=0,
+                    token="ghp_x",
+                )
+        assert result.complete is True
+        assert result.reason is None
+        assert result.matched_count == len(result.repos)
+
+    @pytest.mark.asyncio
+    async def test_cap_sets_max_pages_reached(self) -> None:
+        """Stopping at the page cap with a remaining next-page link reports
+        complete=False, reason=MAX_PAGES_REACHED."""
+        async with ClientSession() as session:
+            with aioresponses() as m:
+                m.get(
+                    "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
+                    body=DEPENDENTS_HTML_PAGE_1,
+                )
+                # Registered so the speculative prefetch has a body to resolve
+                # before it is cancelled when the cap halts the walk.
+                m.get(
+                    "https://github.com/owner/repo/network/dependents?page=2",
+                    body=DEPENDENTS_HTML_LAST_PAGE,
+                )
+                result = await scrape_dependents(
+                    session,
+                    "https://github.com/owner/repo",
+                    min_stars=0,
+                    token="ghp_x",
+                    max_pages=1,
+                )
+        assert result.pages_scraped == 1
+        assert result.complete is False
+        assert result.reason == ScrapeReason.MAX_PAGES_REACHED
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_sets_network_failure(self) -> None:
+        """A failed fetch (the loop's ``html is None`` break) reports
+        complete=False, reason=NETWORK_FAILURE."""
+        async with ClientSession() as session:
+            with aioresponses() as m:
+                m.get(
+                    "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
+                    status=500,
+                )
+                result = await scrape_dependents(
+                    session,
+                    "https://github.com/owner/repo",
+                    min_stars=0,
+                    token="ghp_x",
+                )
+        assert result.complete is False
+        assert result.reason == ScrapeReason.NETWORK_FAILURE
+        assert result.pages_scraped == 0  # a failed first fetch consumed zero pages
 
 
 class TestScrapeDependentsEdgeCases:


### PR DESCRIPTION
## Summary

Phase 1 of the scraper-hardening effort (issue #74): adds the **internal** scrape-result contract and an adaptive rate-limiter primitive, with **no change to user-facing output**.

- **`ScrapeReason` enum + `ScrapeResult` contract fields** (`models.py`): adds `complete`/`reason`/`matched_count` to the *internal, non-serialized* `ScrapeResult`, guarded by a `complete == (reason is None)` model invariant. The four documented stop reasons (`MAX_PAGES_REACHED`, `TREND_CONVERGED`, `NETWORK_FAILURE`, `RATE_LIMITED`) are all representable.
- **Honest population in the existing scraper** (`scraper.py`): `scrape_dependents` now fills those fields from its own termination state. The page counter was moved to count only *consumed* pages (a failed first fetch now reports `pages_scraped == 0`), and a `fetch_failed` flag drives a safe terminal classification (`NETWORK_FAILURE` / `MAX_PAGES_REACHED` / clean exhaustion). The pre-AIMD scraper can only distinguish these three; `TREND_CONVERGED` and the `RATE_LIMITED` split arrive with the Phase 2 streaming rewrite.
- **`try_acquire()` / `tokens_available()` on `TokenBucketRateLimiter`** (`rate_limiter.py`): non-blocking, lock-aware acquire with a `reserve` headroom param so background work yields tokens to foreground callers.
- **`AdaptiveRateLimiter`** (`rate_limiter.py`): wraps the bucket with AIMD concurrency control, exponential 429 backoff (jittered, honoring `Retry-After`), and auth/unauth rate selection (60/min with a token, 1/min without). Added now for the Phase 2 streaming scraper; `current_max_concurrency` is advisory and not yet consumed.

### Deliberately out of scope (per the plan)

- The user-facing `DependentsResult` fields are **not** added here — `dep-rank deps --format json` output is byte-identical to before. They land in Phase 4, once the scraper populates them honestly.
- No module-level rate-limiter singletons are rewired — Phase 2 swaps them for `AdaptiveRateLimiter`.

## Test Plan

- [x] `uv run pytest` — full suite green: **142 passed, 93.14% coverage** (90% gate)
- [x] `uv run ruff check src tests && uv run ruff format --check src tests` — clean
- [x] New module `rate_limiter.py` at 100% coverage
- [x] `DependentsResult` and CLI/formatter untouched — JSON output unchanged
- [x] Per-task spec + quality reviews and a final holistic review all passed

Refs #74.
