### PR TITLE
feat: scraper hardening phase 2 — streaming heap aggregator + adaptive stop

### DIFF
--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -58,6 +58,23 @@ class ScrapeResult(BaseModel):
         return self
 
 
+class ScrapeSnapshot(BaseModel):
+    """One emission from the streaming scraper.
+
+    Per-page emissions have ``done=False``; exactly one terminal emission has
+    ``done=True`` and carries the authoritative ``complete``/``reason``.
+    """
+
+    top_k: list[Repository]
+    pages_scraped: int
+    estimated_total_pages: int
+    estimated_total_dependents: int
+    matched_count: int
+    done: bool = False
+    complete: bool = False
+    reason: ScrapeReason | None = None
+
+
 class DependentsResult(BaseModel):
     """Result of scraping dependents for a repository."""
 

--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -3,17 +3,26 @@
 from __future__ import annotations
 
 import asyncio
+import heapq
+import itertools
 import logging
 import random
 import re
-from collections.abc import Awaitable, Callable
+from collections import deque
+from collections.abc import AsyncIterator, Awaitable, Callable
 
 import aiohttp
 from selectolax.parser import HTMLParser
 
 from dep_rank.core.cache import SqliteCache
-from dep_rank.core.models import DependentType, Repository, ScrapeReason, ScrapeResult
-from dep_rank.core.rate_limiter import TokenBucketRateLimiter
+from dep_rank.core.models import (
+    DependentType,
+    Repository,
+    ScrapeReason,
+    ScrapeResult,
+    ScrapeSnapshot,
+)
+from dep_rank.core.rate_limiter import AdaptiveRateLimiter
 from dep_rank.core.validation import validate_github_url
 
 logger = logging.getLogger(__name__)
@@ -23,15 +32,30 @@ REPO_SELECTOR = "span > a.text-bold"
 STARS_SELECTOR = "div > div > span"
 NEXT_BUTTON_SELECTOR = "#dependents > div.paginate-container > div > a"
 GITHUB_URL = "https://github.com"
-MAX_PAGES = 1000
 MAX_RETRIES = 5
 REQUEST_TIMEOUT = 30
 CACHE_TTL = 86400  # 24 hours
 DEPENDENTS_PER_PAGE = 30  # Approximate dependents shown per GitHub page
 RETRY_BASE_SECONDS = 5
 RETRY_MAX_SECONDS = 120
-_RATE_LIMITER_UNAUTH = TokenBucketRateLimiter(rate=10, period=60.0)
-_RATE_LIMITER_AUTH = TokenBucketRateLimiter(rate=60, period=60.0)
+MAX_PAGES_CEILING = 1000
+DEFAULT_MAX_PAGES = 200
+DEFAULT_CONCURRENCY = 3
+ADAPTIVE_WINDOW = 20  # trailing pages examined for the trend
+ADAPTIVE_W_MIN = 30  # minimum pages before adaptive stop may fire
+MAX_PAGES = MAX_PAGES_CEILING  # back-compat: cli.app's search progress bar imports this
+
+
+class ScrapeError(Exception):
+    """Base class for terminal scrape failures."""
+
+
+class NetworkFailureError(ScrapeError):
+    """A page could not be fetched after the retry budget (or an unexpected status)."""
+
+
+class RateLimitedError(ScrapeError):
+    """The retry budget was exhausted on 429 responses."""
 
 
 def parse_dependents_page(html: str) -> tuple[list[Repository], str | None]:
@@ -126,14 +150,15 @@ def _retry_delay(attempt: int) -> float:
 async def _fetch_page(
     session: aiohttp.ClientSession,
     url: str,
-    rate_limiter: TokenBucketRateLimiter,
+    limiter: AdaptiveRateLimiter,
+    semaphore: asyncio.Semaphore,
     auth_headers: dict[str, str],
     cache: SqliteCache | None,
-) -> tuple[str | None, str | None]:
-    """Fetch a single page with rate limiting, retries, and caching.
+) -> str:
+    """Fetch one page with bounded concurrency, rate limiting, retries, and caching.
 
-    Returns:
-        (html_content, etag) or (None, None) on failure.
+    Returns the HTML body. Raises RateLimitedError or NetworkFailureError when the
+    retry budget is exhausted or an unexpected status is returned.
     """
     timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
     headers: dict[str, str] = {}
@@ -145,56 +170,241 @@ async def _fetch_page(
                 headers["If-None-Match"] = cached["etag"]
             cached_body = cached["body"]
 
+    rate_limited = False
     for attempt in range(MAX_RETRIES + 1):
-        await rate_limiter.acquire()
-        try:
-            async with session.get(
-                url,
-                timeout=timeout,
-                headers={**auth_headers, **headers},
-            ) as resp:
-                if resp.status == 304 and cache and cached_body:
-                    await cache.put(
-                        url,
-                        cached_body,
-                        etag=headers.get("If-None-Match"),
-                        ttl=CACHE_TTL,
-                    )
-                    return cached_body.decode("utf-8"), headers.get("If-None-Match")
-                elif resp.status == 200:
-                    body = await resp.read()
-                    html = body.decode("utf-8")
-                    etag = resp.headers.get("ETag")
-                    if cache:
-                        await cache.put(url, body, etag=etag, ttl=CACHE_TTL)
-                    return html, etag
-                elif resp.status == 429:
-                    delay = _retry_delay(attempt)
-                    retry_after = resp.headers.get("Retry-After")
-                    if retry_after:
-                        delay = max(delay, float(retry_after))
-                    logger.warning(
-                        "Rate limited — retrying in %.1fs (%d/%d)",
-                        delay,
-                        attempt + 1,
-                        MAX_RETRIES,
-                    )
-                    await asyncio.sleep(delay)
-                else:
+        async with semaphore:
+            await limiter.acquire()
+            try:
+                async with session.get(
+                    url, timeout=timeout, headers={**auth_headers, **headers}
+                ) as resp:
+                    if resp.status == 304 and cache and cached_body:
+                        limiter.note_success()
+                        await cache.put(
+                            url, cached_body, etag=headers.get("If-None-Match"), ttl=CACHE_TTL
+                        )
+                        return cached_body.decode("utf-8")
+                    if resp.status == 200:
+                        limiter.note_success()
+                        body: bytes = await resp.read()
+                        if cache:
+                            await cache.put(url, body, etag=resp.headers.get("ETag"), ttl=CACHE_TTL)
+                        return body.decode("utf-8")
+                    if resp.status == 429:
+                        rate_limited = True
+                        retry_after = resp.headers.get("Retry-After")
+                        delay = limiter.note_429(float(retry_after) if retry_after else None)
+                        logger.warning(
+                            "Rate limited — retrying in %.1fs (%d/%d)",
+                            delay,
+                            attempt + 1,
+                            MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
                     logger.warning("Unexpected HTTP %d — stopping", resp.status)
-                    return None, None
-        except (TimeoutError, aiohttp.ClientError):
-            delay = _retry_delay(attempt)
-            logger.warning(
-                "Request failed — retrying in %.1fs (%d/%d)",
-                delay,
-                attempt + 1,
-                MAX_RETRIES,
-            )
-            await asyncio.sleep(delay)
+                    raise NetworkFailureError(f"HTTP {resp.status} for {url}")
+            except (TimeoutError, aiohttp.ClientError):
+                delay = _retry_delay(attempt)
+                logger.warning(
+                    "Request failed — retrying in %.1fs (%d/%d)", delay, attempt + 1, MAX_RETRIES
+                )
+                await asyncio.sleep(delay)
 
     logger.warning("Exhausted retries for %s", url)
-    return None, None
+    if rate_limited:
+        raise RateLimitedError(url)
+    raise NetworkFailureError(url)
+
+
+async def _read_page(
+    session: aiohttp.ClientSession,
+    url: str,
+    limiter: AdaptiveRateLimiter,
+    semaphore: asyncio.Semaphore,
+    auth_headers: dict[str, str],
+    cache: SqliteCache | None,
+) -> str:
+    """Return a page's HTML, skipping the network on a fresh cache hit.
+
+    Fresh hit -> cached body (no request). Expired-with-body or miss -> _fetch_page
+    (which revalidates via If-None-Match when an ETag is cached). Phase 3 extends the
+    expired branch with stale-while-revalidate.
+    """
+    if cache:
+        cached = await cache.get(url)
+        if cached and cached["body"] is not None and not cached.get("expired"):
+            body: bytes = cached["body"]
+            return body.decode("utf-8")
+    return await _fetch_page(session, url, limiter, semaphore, auth_headers, cache)
+
+
+def _heap_push(
+    heap: list[tuple[int, int, Repository]], repo: Repository, count: int, rows: int | None
+) -> None:
+    """Maintain a bounded min-heap of the top-``rows`` repos by stars.
+
+    ``rows is None`` keeps every repo (unbounded, back-compat). ``rows <= 0`` keeps none.
+
+    Tie-handling: ``count`` is the monotonically increasing arrival index, stored
+    **negated** so that among repos with equal stars the min-heap root (the eviction
+    candidate) is the *latest-seen* one. Combined with the strict ``>`` admission test
+    below — a new repo whose stars merely *tie* the current minimum is not admitted —
+    this guarantees "ties: earlier-seen wins" both on admission and on eviction.
+    """
+    entry = (repo.stars, -count, repo)
+    if rows is None:
+        heap.append(entry)
+    elif rows <= 0:
+        return
+    elif len(heap) < rows:
+        heapq.heappush(heap, entry)
+    elif repo.stars > heap[0][0]:
+        heapq.heapreplace(heap, entry)
+
+
+def _top_k(heap: list[tuple[int, int, Repository]]) -> list[Repository]:
+    """Return the heap's repos sorted by stars descending (ties: earlier-seen first).
+
+    Heap entries store the arrival index negated (``-count``), so to order ties
+    earliest-first we sort ascending on the *original* index ``-e[1]``.
+    """
+    return [r for _, _, r in sorted(heap, key=lambda e: (-e[0], -e[1]))]
+
+
+def _should_stop(
+    heap: list[tuple[int, int, Repository]],
+    rows: int | None,
+    recent_max: deque[int],
+    page: int,
+) -> bool:
+    """True when the trailing window can no longer plausibly change the saturated top-K."""
+    if rows is None or rows <= 0:
+        return False
+    if len(heap) < rows:  # heap not saturated -> kth_best undefined
+        return False
+    if page < ADAPTIVE_W_MIN:
+        return False
+    if len(recent_max) < ADAPTIVE_WINDOW:
+        return False
+    kth_best = heap[0][0]  # min of the size-rows heap == K-th best stars
+    return max(recent_max) < kth_best
+
+
+def _build_snapshot(
+    heap: list[tuple[int, int, Repository]],
+    page: int,
+    est_pages: int,
+    est_deps: int,
+    matched: int,
+    *,
+    done: bool,
+    reason: ScrapeReason | None = None,
+) -> ScrapeSnapshot:
+    return ScrapeSnapshot(
+        top_k=_top_k(heap),
+        pages_scraped=page,
+        estimated_total_pages=est_pages,
+        estimated_total_dependents=est_deps,
+        matched_count=matched,
+        done=done,
+        complete=(reason is None) if done else False,
+        reason=reason if done else None,
+    )
+
+
+async def stream_dependents(
+    session: aiohttp.ClientSession,
+    url: str,
+    *,
+    rows: int | None,
+    dependent_type: DependentType = DependentType.REPOSITORY,
+    min_stars: int = 5,
+    cache: SqliteCache | None = None,
+    on_progress: Callable[[int, int], Awaitable[None]] | None = None,
+    token: str | None = None,
+    max_pages: int = DEFAULT_MAX_PAGES,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    adaptive_stop: bool = True,
+    rate_limiter: AdaptiveRateLimiter | None = None,
+) -> AsyncIterator[ScrapeSnapshot]:
+    """Stream top-K dependents page by page.
+
+    Yields one snapshot per consumed page (done=False) then exactly one terminal
+    snapshot (done=True) carrying complete/reason. ``rows is None`` keeps every
+    matched repo and disables adaptive stop (back-compat for the wrapper).
+    """
+    if not 1 <= concurrency <= 10:
+        msg = f"concurrency must be between 1 and 10, got {concurrency}"
+        raise ValueError(msg)
+    owner, repo = validate_github_url(url)
+    base_url = f"{GITHUB_URL}/{owner}/{repo}/network/dependents"
+    current_url: str | None = f"{base_url}?dependent_type={dependent_type.value}"
+    source_url = f"{GITHUB_URL}/{owner}/{repo}"
+
+    max_pages = min(max_pages, MAX_PAGES_CEILING)
+    limiter = rate_limiter or AdaptiveRateLimiter.for_token(token, concurrency)
+    semaphore = asyncio.Semaphore(concurrency)
+    auth_headers: dict[str, str] = {"Authorization": f"token {token}"} if token else {}
+
+    heap: list[tuple[int, int, Repository]] = []
+    counter = itertools.count()
+    seen: set[str] = set()
+    matched = 0
+    est_pages = 0
+    est_deps = 0
+    recent_max: deque[int] = deque(maxlen=ADAPTIVE_WINDOW)
+    bounded = rows is not None
+    page = 0
+    reason: ScrapeReason | None = None
+
+    while current_url and page < max_pages:
+        try:
+            html = await _read_page(session, current_url, limiter, semaphore, auth_headers, cache)
+        except RateLimitedError:
+            reason = ScrapeReason.RATE_LIMITED
+            break
+        except NetworkFailureError:
+            reason = ScrapeReason.NETWORK_FAILURE
+            break
+        page += 1  # increment only after a page is actually consumed (spec §2)
+
+        if page == 1:
+            counts = parse_dependent_counts(html)
+            est_deps = counts.get(dependent_type.value, 0)
+            est_pages = est_deps // DEPENDENTS_PER_PAGE if est_deps > 0 else 0
+
+        repos, next_url = parse_dependents_page(html)
+        page_max = 0
+        for repo_obj in repos:
+            if repo_obj.url in seen or repo_obj.url == source_url:
+                continue
+            if repo_obj.stars >= min_stars:
+                seen.add(repo_obj.url)
+                matched += 1
+                page_max = max(page_max, repo_obj.stars)
+                _heap_push(heap, repo_obj, next(counter), rows)
+        recent_max.append(page_max)
+
+        if on_progress:
+            await on_progress(page, est_pages)
+        yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=False)
+
+        if adaptive_stop and bounded and _should_stop(heap, rows, recent_max, page):
+            reason = ScrapeReason.TREND_CONVERGED
+            break
+        current_url = next_url
+    else:
+        # Loop exited via its condition (no break): exhausted, unless we stopped at the cap.
+        if current_url is not None and page >= max_pages:
+            reason = ScrapeReason.MAX_PAGES_REACHED
+
+    # `estimated_total_pages` is always the header-derived estimate (`est_pages`),
+    # matching the historical scraper (it returned the header estimate unconditionally).
+    # Actual pages consumed live in `pages_scraped`; do NOT overwrite the estimate with
+    # `page` on completion — Phase 4 summaries and existing header-estimate tests depend
+    # on the estimate staying the population projection, not the walked count.
+    yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=True, reason=reason)
 
 
 async def scrape_dependents(
@@ -205,130 +415,48 @@ async def scrape_dependents(
     cache: SqliteCache | None = None,
     on_progress: Callable[[int, int], Awaitable[None]] | None = None,
     token: str | None = None,
-    max_pages: int = MAX_PAGES,
+    max_pages: int = MAX_PAGES_CEILING,
+    *,
+    rows: int | None = None,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    adaptive_stop: bool = True,
+    rate_limiter: AdaptiveRateLimiter | None = None,
 ) -> ScrapeResult:
-    """Scrape GitHub dependents pages and return repositories sorted by stars.
+    """Compatibility wrapper: drain stream_dependents into a ScrapeResult.
 
-    Uses a prefetch pipeline: while processing page N, page N+1 is already
-    being fetched. Cache hits skip the network entirely.
-
-    Args:
-        session: aiohttp client session.
-        url: GitHub repository URL.
-        dependent_type: REPOSITORY or PACKAGE.
-        min_stars: Minimum star count to include.
-        cache: Optional SQLite cache for HTTP responses.
-        on_progress: Optional async callback(current_page, estimated_total_pages).
-        token: Optional GitHub token for authenticated scraping (higher rate limits).
-        max_pages: Maximum number of pages to scrape (default: 1000).
+    ``rows is None`` (default) returns every matched repo, sorted by stars, and
+    ``max_pages`` defaults to ``MAX_PAGES_CEILING`` (1000) — the historical
+    "return everything up to the ceiling" behavior, deliberately *overriding* the
+    bounded 200-page (`DEFAULT_MAX_PAGES`) default of ``stream_dependents``. This
+    keeps existing callers (the ``deps``/``search`` CLI in `app.py`, which pass no
+    ``max_pages`` or their own) unchanged until Phase 4 introduces a user-facing
+    ``--max-pages`` budget. Pass ``rows`` for a bounded top-K with adaptive stop.
     """
-    owner, repo = validate_github_url(url)
-    base_url = f"{GITHUB_URL}/{owner}/{repo}/network/dependents"
-    current_url: str | None = f"{base_url}?dependent_type={dependent_type.value}"
-
-    rate_limiter = _RATE_LIMITER_AUTH if token else _RATE_LIMITER_UNAUTH
-    auth_headers: dict[str, str] = {"Authorization": f"token {token}"} if token else {}
-
-    all_repos: list[Repository] = []
-    seen_urls: set[str] = set()
-    source_url = f"{GITHUB_URL}/{owner}/{repo}"
-    page = 0
-    prefetch_task: asyncio.Task[tuple[str | None, str | None]] | None = None
-    estimated_total_pages = 0
-    estimated_total_dependents = 0
-    fetch_failed = False
-
-    while current_url and page < max_pages:
-        # Check cache first
-        html: str | None = None
-        cache_hit = False
-        if cache:
-            cached = await cache.get(current_url)
-            if cached and cached["body"] is not None and not cached.get("expired"):
-                html = cached["body"].decode("utf-8")
-                cache_hit = True
-
-        if html is None:
-            # Use prefetched result if available, otherwise fetch now
-            if prefetch_task is not None:
-                html, _etag = await prefetch_task
-                prefetch_task = None
-            else:
-                html, _etag = await _fetch_page(
-                    session,
-                    current_url,
-                    rate_limiter,
-                    auth_headers,
-                    cache,
-                )
-
-            if html is None:
-                fetch_failed = True
-                break
-
-        page += 1
-
-        if page == 1:
-            counts = parse_dependent_counts(html)
-            dep_count = counts.get(dependent_type.value, 0)
-            estimated_total_dependents = dep_count
-            estimated_total_pages = dep_count // DEPENDENTS_PER_PAGE if dep_count > 0 else 0
-
-        # Parse current page
-        repos, next_url = parse_dependents_page(html)
-
-        # Start prefetching next page if it's not cached
-        if next_url and prefetch_task is None:
-            next_cached = False
-            if cache:
-                next_entry = await cache.get(next_url)
-                next_cached = bool(
-                    next_entry and next_entry["body"] is not None and not next_entry.get("expired")
-                )
-            if not next_cached:
-                prefetch_task = asyncio.create_task(
-                    _fetch_page(session, next_url, rate_limiter, auth_headers, cache)
-                )
-
-        for repo_obj in repos:
-            if repo_obj.url in seen_urls or repo_obj.url == source_url:
-                continue
-            if repo_obj.stars >= min_stars:
-                seen_urls.add(repo_obj.url)
-                all_repos.append(repo_obj)
-
-        logger.debug("Page %d: %s", page, "cache hit" if cache_hit else "network fetch")
-        if on_progress:
-            await on_progress(page, estimated_total_pages)
-
-        current_url = next_url
-
-    # Cancel any outstanding prefetch
-    if prefetch_task is not None:
-        prefetch_task.cancel()
-        try:
-            await prefetch_task
-        except asyncio.CancelledError:
-            pass  # Expected when scraping ends before prefetch completes
-
-    # Classify how the walk ended. `fetch_failed` is set only by the `html is None`
-    # break above; a clean exhaustion drops `current_url` to None, and hitting the cap
-    # leaves `current_url` pointing at an unfetched next page with `page == max_pages`.
-    if fetch_failed:
-        reason: ScrapeReason | None = ScrapeReason.NETWORK_FAILURE
-    elif current_url is not None and page >= max_pages:
-        reason = ScrapeReason.MAX_PAGES_REACHED
-    else:
-        reason = None
-
-    all_repos.sort(key=lambda r: r.stars, reverse=True)
-    return ScrapeResult(
-        repos=all_repos,
-        pages_scraped=page,
+    terminal: ScrapeSnapshot | None = None
+    async for snapshot in stream_dependents(
+        session,
+        url,
+        rows=rows,
+        dependent_type=dependent_type,
+        min_stars=min_stars,
+        cache=cache,
+        on_progress=on_progress,
+        token=token,
         max_pages=max_pages,
-        estimated_total_pages=estimated_total_pages,
-        estimated_total_dependents=estimated_total_dependents,
-        complete=reason is None,
-        reason=reason,
-        matched_count=len(all_repos),
+        concurrency=concurrency,
+        adaptive_stop=adaptive_stop,
+        rate_limiter=rate_limiter,
+    ):
+        terminal = snapshot
+
+    assert terminal is not None  # noqa: S101  # stream always yields a terminal snapshot
+    return ScrapeResult(
+        repos=terminal.top_k,
+        pages_scraped=terminal.pages_scraped,
+        max_pages=min(max_pages, MAX_PAGES_CEILING),
+        estimated_total_pages=terminal.estimated_total_pages,
+        estimated_total_dependents=terminal.estimated_total_dependents,
+        complete=terminal.complete,
+        reason=terminal.reason,
+        matched_count=terminal.matched_count,
     )

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -216,3 +216,36 @@ class TestScrapeResultContractFields:
         )
         assert result.complete is False
         assert result.reason == reason
+
+
+class TestScrapeSnapshot:
+    def test_per_page_snapshot_defaults(self) -> None:
+        from dep_rank.core.models import ScrapeSnapshot
+
+        snap = ScrapeSnapshot(
+            top_k=[],
+            pages_scraped=1,
+            estimated_total_pages=3,
+            estimated_total_dependents=90,
+            matched_count=2,
+        )
+        assert snap.done is False
+        assert snap.complete is False
+        assert snap.reason is None
+
+    def test_terminal_snapshot(self) -> None:
+        from dep_rank.core.models import ScrapeReason, ScrapeSnapshot
+
+        snap = ScrapeSnapshot(
+            top_k=[],
+            pages_scraped=200,
+            estimated_total_pages=500,
+            estimated_total_dependents=15000,
+            matched_count=4200,
+            done=True,
+            complete=False,
+            reason=ScrapeReason.MAX_PAGES_REACHED,
+        )
+        assert snap.done is True
+        assert snap.complete is False
+        assert snap.reason == "max_pages_reached"

--- a/tests/core/test_scraper.py
+++ b/tests/core/test_scraper.py
@@ -274,8 +274,8 @@ class TestScrapeDependents:
 
     @pytest.mark.asyncio
     async def test_fetch_failure_sets_network_failure(self) -> None:
-        """A failed fetch (the loop's ``html is None`` break) reports
-        complete=False, reason=NETWORK_FAILURE."""
+        """A fetch that fails with an unexpected status (raising
+        ``NetworkFailureError``) reports complete=False, reason=NETWORK_FAILURE."""
         async with ClientSession() as session:
             with aioresponses() as m:
                 m.get(

--- a/tests/core/test_scraper.py
+++ b/tests/core/test_scraper.py
@@ -7,6 +7,7 @@ from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from dep_rank.core.models import DependentType, Repository, ScrapeReason, ScrapeResult
+from dep_rank.core.rate_limiter import AdaptiveRateLimiter
 from dep_rank.core.scraper import parse_dependent_counts, parse_dependents_page, scrape_dependents
 from tests.conftest import (
     DEPENDENTS_HTML_LAST_PAGE,
@@ -15,6 +16,17 @@ from tests.conftest import (
     DEPENDENTS_HTML_WITH_COUNTS,
     DEPENDENTS_HTML_WITH_COUNTS_PAGE_1,
 )
+
+
+def _fast_limiter() -> AdaptiveRateLimiter:
+    """A non-throttling limiter for multi-page tests not about rate limiting.
+
+    A token-less scrape builds the unauthenticated 1/min limiter, whose lone token is
+    drained by page 1; page 2's ``acquire()`` would then ``asyncio.sleep(~60)``. These
+    tests exercise pagination/filtering/progress/estimates, not throttling, so inject a
+    high-capacity bucket that never blocks.
+    """
+    return AdaptiveRateLimiter(rate=100_000, period=1.0, concurrency=3)
 
 
 class TestParseDependentCounts:
@@ -142,7 +154,9 @@ class TestScrapeDependents:
                 body=DEPENDENTS_HTML_LAST_PAGE,
             )
             async with ClientSession() as session:
-                result = await scrape_dependents(session, "https://github.com/owner/repo")
+                result = await scrape_dependents(
+                    session, "https://github.com/owner/repo", rate_limiter=_fast_limiter()
+                )
             assert len(result.repos) == 4
 
     @pytest.mark.asyncio
@@ -161,6 +175,7 @@ class TestScrapeDependents:
                     session,
                     "https://github.com/owner/repo",
                     min_stars=200,
+                    rate_limiter=_fast_limiter(),
                 )
             assert all(r.stars >= 200 for r in result.repos)
 
@@ -179,7 +194,9 @@ class TestScrapeDependents:
                 body=DEPENDENTS_HTML_LAST_PAGE,
             )
             async with ClientSession() as session:
-                result = await scrape_dependents(session, "https://github.com/owner/repo")
+                result = await scrape_dependents(
+                    session, "https://github.com/owner/repo", rate_limiter=_fast_limiter()
+                )
             urls = [r.url for r in result.repos]
             assert len(urls) == len(set(urls))
 
@@ -219,6 +236,7 @@ class TestScrapeDependents:
                     session,
                     "https://github.com/owner/repo",
                     on_progress=on_progress,
+                    rate_limiter=_fast_limiter(),
                 )
         assert len(progress_calls) == 2
         # 90 repos / 30 per page = 3 estimated total pages
@@ -558,6 +576,7 @@ class TestScrapeResultReturn:
                     session,
                     "https://github.com/owner/repo",
                     on_progress=on_progress,
+                    rate_limiter=_fast_limiter(),
                 )
         assert result.pages_scraped == 2
         assert result.estimated_total_pages == 30  # 900 // 30

--- a/tests/core/test_scraper.py
+++ b/tests/core/test_scraper.py
@@ -255,8 +255,8 @@ class TestScrapeDependents:
                     "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
                     body=DEPENDENTS_HTML_PAGE_1,
                 )
-                # Registered so the speculative prefetch has a body to resolve
-                # before it is cancelled when the cap halts the walk.
+                # Registered only to give page 1 a valid next-page link; with
+                # max_pages=1 the walk caps before page 2 is ever fetched.
                 m.get(
                     "https://github.com/owner/repo/network/dependents?page=2",
                     body=DEPENDENTS_HTML_LAST_PAGE,
@@ -355,8 +355,10 @@ class TestScrapeDependentsEdgeCases:
         assert len(repos) == 0
 
     @pytest.mark.asyncio
-    async def test_error_response_breaks_scraping(self) -> None:
-        """Non-200, non-304 response stops scraping."""
+    async def test_error_response_sets_network_failure(self) -> None:
+        """A non-200/304/429 response terminates with reason=network_failure."""
+        from dep_rank.core.models import ScrapeReason
+
         with aioresponses() as m:
             m.get(
                 "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
@@ -364,37 +366,42 @@ class TestScrapeDependentsEdgeCases:
             )
             async with ClientSession() as session:
                 result = await scrape_dependents(session, "https://github.com/owner/repo")
-        assert len(result.repos) == 0
+        assert result.repos == []
+        assert result.complete is False
+        assert result.reason == ScrapeReason.NETWORK_FAILURE
+        assert result.pages_scraped == 0  # first-page failure consumed no pages
 
     @pytest.mark.asyncio
-    async def test_304_without_cached_body_breaks(self) -> None:
-        """304 response when cache has no body results in empty results."""
-        from dep_rank.core.cache import SqliteCache
+    async def test_429_exhaustion_sets_rate_limited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A persistent 429 (past the retry budget) terminates with reason=rate_limited."""
+        from unittest.mock import AsyncMock
 
+        from dep_rank.core.models import ScrapeReason
+
+        # Patch the scraper's sleep so the (growing) 429 backoff does not actually wait.
+        monkeypatch.setattr("dep_rank.core.scraper.asyncio.sleep", AsyncMock())
+
+        url = "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY"
         with aioresponses() as m:
-            m.get(
-                "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
-                status=304,
-            )
+            for _ in range(6):  # MAX_RETRIES + 1 attempts, all 429
+                m.get(url, status=429, headers={"Retry-After": "0"})
             async with ClientSession() as session:
-                # Create a real cache but with an expired entry (body=None after expiry)
-                import tempfile
+                result = await scrape_dependents(
+                    session, "https://github.com/owner/repo", token="ghp_x"
+                )
+        assert result.complete is False
+        assert result.reason == ScrapeReason.RATE_LIMITED
+        assert result.pages_scraped == 0  # never got a parseable page
 
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    cache = SqliteCache(tmpdir)
-                    await cache.initialize()
-                    # Put an expired entry so etag is returned but body is None
-                    await cache.put(
-                        "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY",
-                        b"old-html",
-                        etag='"etag1"',
-                        ttl=-1,
+    @pytest.mark.asyncio
+    async def test_concurrency_out_of_range_raises(self) -> None:
+        """The library refuses concurrency <1 or >10 (avoids Semaphore(0) deadlock)."""
+        async with ClientSession() as session:
+            for bad in (0, 11):
+                with pytest.raises(ValueError, match="concurrency"):
+                    await scrape_dependents(
+                        session, "https://github.com/owner/repo", concurrency=bad
                     )
-                    result = await scrape_dependents(
-                        session, "https://github.com/owner/repo", cache=cache
-                    )
-                    await cache.close()
-        assert len(result.repos) == 0
 
     @pytest.mark.asyncio
     async def test_cache_hit_skips_network(self) -> None:

--- a/tests/core/test_scraper_adaptive_stop.py
+++ b/tests/core/test_scraper_adaptive_stop.py
@@ -1,0 +1,161 @@
+"""Tests for adaptive early-stopping (predicate + end-to-end termination)."""
+
+from __future__ import annotations
+
+import heapq
+from collections import deque
+
+import pytest
+from aiohttp import ClientSession
+from aioresponses import aioresponses
+
+from dep_rank.core.models import Repository, ScrapeReason
+from dep_rank.core.rate_limiter import AdaptiveRateLimiter
+from dep_rank.core.scraper import (
+    ADAPTIVE_W_MIN,
+    ADAPTIVE_WINDOW,
+    _should_stop,
+    scrape_dependents,
+)
+
+
+def _fast_limiter() -> AdaptiveRateLimiter:
+    """A non-throttling limiter for the long end-to-end walks below.
+
+    These tests page through ``ADAPTIVE_W_MIN + ADAPTIVE_WINDOW + 5`` (~55) pages. The
+    default unauthenticated limiter is 1/min, and even the authenticated 60/min bucket
+    leaves only a ~5-token margin over this walk — fragile if the window constants grow.
+    Inject a high-capacity bucket so ``acquire()`` never blocks regardless of page count.
+    """
+    return AdaptiveRateLimiter(rate=100_000, period=1.0, concurrency=3)
+
+
+def _heap(stars: list[int]) -> list[tuple[int, int, Repository]]:
+    """Build a *real* min-heap (not a plain list) so ``heap[0]`` is the smallest entry.
+
+    ``_should_stop`` reads ``heap[0][0]`` as the K-th best (the heap minimum). A plain
+    list comprehension in arbitrary order would leave ``heap[0]`` as the *first* element
+    (e.g. the largest), so the predicate would compare the trailing window against the
+    wrong threshold — silently mis-passing or mis-failing. ``heapq.heapify`` restores the
+    invariant. (``count`` need not be negated here: these entries are never displaced via
+    ``_heap_push``; only ``heap[0][0]`` — the stars — is inspected.)
+    """
+    h = [
+        (s, i, Repository(owner="o", name=f"r{i}", url=f"https://github.com/o/r{i}", stars=s))
+        for i, s in enumerate(stars)
+    ]
+    heapq.heapify(h)
+    return h
+
+
+class TestShouldStopPredicate:
+    def test_converged_stops(self) -> None:
+        heap = _heap([1000, 900, 800])  # kth_best (min) = 800
+        recent = deque([10, 20, 5] * 7, maxlen=ADAPTIVE_WINDOW)  # all far below 800
+        assert _should_stop(heap, rows=3, recent_max=recent, page=ADAPTIVE_W_MIN) is True
+
+    def test_non_converged_continues(self) -> None:
+        heap = _heap([1000, 900, 800])
+        recent = deque([850] * ADAPTIVE_WINDOW, maxlen=ADAPTIVE_WINDOW)  # exceeds kth_best=800
+        assert _should_stop(heap, rows=3, recent_max=recent, page=ADAPTIVE_W_MIN) is False
+
+    def test_sparse_min_stars_never_saturates(self) -> None:
+        heap = _heap([1000, 900])  # only 2 < rows=3 -> not saturated
+        recent = deque([5] * ADAPTIVE_WINDOW, maxlen=ADAPTIVE_WINDOW)
+        assert _should_stop(heap, rows=3, recent_max=recent, page=ADAPTIVE_W_MIN) is False
+
+    def test_no_stop_before_w_min(self) -> None:
+        heap = _heap([1000, 900, 800])
+        recent = deque([5] * ADAPTIVE_WINDOW, maxlen=ADAPTIVE_WINDOW)
+        assert _should_stop(heap, rows=3, recent_max=recent, page=ADAPTIVE_W_MIN - 1) is False
+
+    def test_rows_none_never_stops(self) -> None:
+        heap = _heap([1000, 900, 800])
+        recent = deque([5] * ADAPTIVE_WINDOW, maxlen=ADAPTIVE_WINDOW)
+        assert _should_stop(heap, rows=None, recent_max=recent, page=999) is False
+
+
+# --- End-to-end: a decaying-star stream stops early with trend_converged ---
+
+FIRST = "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY"
+
+
+def _item(name: str, stars: int) -> str:
+    return (
+        f'<div class="flex-items-center"><span>'
+        f'<a class="text-bold" href="/o/{name}">o/{name}</a></span>'
+        f"<div><span>{stars}</span></div></div>"
+    )
+
+
+def _decaying_page(page_num: int, total_pages: int) -> str:
+    # Page 1 seeds three high-star repos; later pages are all low-star.
+    if page_num == 1:
+        body = _item("a", 9000) + _item("b", 8000) + _item("c", 7000)
+    else:
+        body = _item(f"low{page_num}", 10)
+    nav = (
+        f'<a href="/owner/repo/network/dependents?page={page_num + 1}">Next</a>'
+        if page_num < total_pages
+        else '<a href="/owner/repo/network/dependents?page=0">Previous</a>'
+    )
+    return f"""
+    <html><body>
+    <div class="table-list-header-toggle states flex-auto pl-0">
+        <a class="btn-link selected"
+           href="/owner/repo/network/dependents?dependent_type=REPOSITORY">3000 Repositories</a>
+    </div>
+    <div id="dependents"><div class="Box">{body}</div>
+    <div class="paginate-container"><div>{nav}</div></div></div>
+    </body></html>
+    """
+
+
+@pytest.mark.asyncio
+async def test_decaying_stream_stops_with_trend_converged() -> None:
+    total = ADAPTIVE_W_MIN + ADAPTIVE_WINDOW + 5  # enough pages to satisfy W_min + window
+    with aioresponses() as m:
+        m.get(FIRST, body=_decaying_page(1, total))
+        for p in range(2, total + 1):
+            m.get(
+                f"https://github.com/owner/repo/network/dependents?page={p}",
+                body=_decaying_page(p, total),
+            )
+        async with ClientSession() as session:
+            result = await scrape_dependents(
+                session,
+                "https://github.com/owner/repo",
+                rows=3,
+                min_stars=5,
+                max_pages=1000,
+                rate_limiter=_fast_limiter(),
+            )
+    assert result.reason == ScrapeReason.TREND_CONVERGED
+    assert result.complete is False
+    assert result.pages_scraped < total  # stopped before exhausting
+    assert [r.name for r in result.repos] == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_no_adaptive_stop_runs_to_exhaustion() -> None:
+    total = ADAPTIVE_W_MIN + ADAPTIVE_WINDOW + 5
+    with aioresponses() as m:
+        m.get(FIRST, body=_decaying_page(1, total))
+        for p in range(2, total + 1):
+            m.get(
+                f"https://github.com/owner/repo/network/dependents?page={p}",
+                body=_decaying_page(p, total),
+            )
+        async with ClientSession() as session:
+            result = await scrape_dependents(
+                session,
+                "https://github.com/owner/repo",
+                rows=3,
+                min_stars=5,
+                max_pages=1000,
+                adaptive_stop=False,
+                rate_limiter=_fast_limiter(),
+            )
+    assert result.complete is True
+    assert result.reason is None
+    assert result.pages_scraped == total

--- a/tests/core/test_scraper_concurrency.py
+++ b/tests/core/test_scraper_concurrency.py
@@ -1,0 +1,74 @@
+"""Tests that the bounded-concurrency fetch window is respected."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from dep_rank.core.rate_limiter import AdaptiveRateLimiter
+from dep_rank.core.scraper import _fetch_page
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, counter: _Counter) -> None:
+        self._counter = counter
+        self.headers: dict[str, str] = {}
+
+    async def __aenter__(self) -> _FakeResponse:
+        self._counter.enter()
+        await asyncio.sleep(0.02)  # hold the slot so overlap is observable
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._counter.exit()
+
+    async def read(self) -> bytes:
+        return b"<html></html>"
+
+
+class _Counter:
+    def __init__(self) -> None:
+        self.current = 0
+        self.peak = 0
+
+    def enter(self) -> None:
+        self.current += 1
+        self.peak = max(self.peak, self.current)
+
+    def exit(self) -> None:
+        self.current -= 1
+
+
+class _FakeSession:
+    def __init__(self, counter: _Counter) -> None:
+        self._counter = counter
+
+    def get(self, url: str, **kwargs: object) -> _FakeResponse:  # noqa: ARG002
+        return _FakeResponse(self._counter)
+
+
+@pytest.mark.asyncio
+async def test_fetch_window_never_exceeds_concurrency() -> None:
+    concurrency = 3
+    counter = _Counter()
+    session = _FakeSession(counter)
+    # Fast, generous limiter so the semaphore is the only bound under test.
+    limiter = AdaptiveRateLimiter(1000, 0.001, concurrency)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def fetch(i: int) -> str:
+        return await _fetch_page(  # type: ignore[no-any-return]
+            session,
+            f"https://github.com/o/r/network/dependents?page={i}",
+            limiter,
+            semaphore,
+            {},
+            None,
+        )
+
+    await asyncio.gather(*(fetch(i) for i in range(12)))
+    assert counter.peak <= concurrency
+    assert counter.peak >= 2  # sanity: some overlap actually happened

--- a/tests/core/test_scraper_streaming.py
+++ b/tests/core/test_scraper_streaming.py
@@ -1,0 +1,173 @@
+"""Tests for the streaming heap aggregator (top-K correctness + edge cases).
+
+Multi-page tests pass ``token="ghp_x"`` so the per-scrape limiter is built via
+``AdaptiveRateLimiter.for_token("ghp_x", ...)`` — the authenticated 60/min budget
+(bucket capacity 60, starts full), so ``acquire()`` returns immediately for every page.
+Without a token the limiter is the unauthenticated **1/min** bucket: page 1 drains the
+lone token and page 2's ``acquire()`` does a real ``asyncio.sleep(60)``, hanging the
+test. Single-page tests (``next_page=None``) make exactly one ``acquire()`` and so don't
+need a token, but passing one is harmless.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import ClientSession
+from aioresponses import aioresponses
+
+from dep_rank.core.scraper import scrape_dependents, stream_dependents
+
+BASE = "https://github.com/owner/repo"
+FIRST = "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY"
+
+
+def _page(rows_html: str, next_page: int | None) -> str:
+    nav = (
+        f'<a href="/owner/repo/network/dependents?page={next_page}">Next</a>'
+        if next_page is not None
+        else '<a href="/owner/repo/network/dependents?page=0">Previous</a>'
+    )
+    return f"""
+    <html><body>
+    <div class="table-list-header-toggle states flex-auto pl-0">
+        <a class="btn-link selected"
+           href="/owner/repo/network/dependents?dependent_type=REPOSITORY">300 Repositories</a>
+    </div>
+    <div id="dependents"><div class="Box">{rows_html}</div>
+    <div class="paginate-container"><div>{nav}</div></div></div>
+    </body></html>
+    """
+
+
+def _item(owner: str, name: str, stars: int) -> str:
+    return f"""
+    <div class="flex-items-center">
+        <span><a class="text-bold" href="/{owner}/{name}">{owner}/{name}</a></span>
+        <div><span>{stars}</span></div>
+    </div>
+    """
+
+
+@pytest.mark.asyncio
+async def test_top_k_ordering_across_pages() -> None:
+    """rows=2 keeps the two highest-star repos regardless of which page they were on."""
+    p1 = _page(_item("a", "one", 100) + _item("b", "two", 5000), next_page=2)
+    p2 = _page(_item("c", "three", 9000) + _item("d", "four", 200), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        m.get("https://github.com/owner/repo/network/dependents?page=2", body=p2)
+        async with ClientSession() as session:
+            result = await scrape_dependents(
+                session, BASE, rows=2, token="ghp_x", adaptive_stop=False
+            )
+    assert [r.name for r in result.repos] == ["three", "two"]
+    assert result.repos[0].stars == 9000
+    assert result.matched_count == 4  # all four passed min_stars=5
+    assert result.complete is True
+
+
+@pytest.mark.asyncio
+async def test_rows_zero_keeps_no_repos_but_counts() -> None:
+    p1 = _page(_item("a", "one", 100) + _item("b", "two", 50), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        async with ClientSession() as session:
+            result = await scrape_dependents(session, BASE, rows=0)
+    assert result.repos == []
+    assert result.matched_count == 2
+
+
+@pytest.mark.asyncio
+async def test_rows_greater_than_total_returns_all() -> None:
+    p1 = _page(_item("a", "one", 100) + _item("b", "two", 50), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        async with ClientSession() as session:
+            result = await scrape_dependents(session, BASE, rows=50)
+    assert [r.name for r in result.repos] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_ties_keep_earlier_seen() -> None:
+    """Equal stars: the repo seen first is retained when the heap is full."""
+    p1 = _page(_item("a", "first", 500) + _item("b", "second", 500), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        async with ClientSession() as session:
+            result = await scrape_dependents(session, BASE, rows=1)
+    assert [r.name for r in result.repos] == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_ties_evict_later_seen_when_displaced() -> None:
+    """Regression for the eviction tiebreak (not just admission): when a
+    higher-star repo displaces one of two equal-star repos in a full heap, the
+    *later-seen* tie must be evicted and the earlier-seen one retained.
+
+    Fails under a plain ``(stars, count, repo)`` entry (the min-heap root is the
+    earliest-seen tie, so it gets evicted first) — only ``(stars, -count, repo)``
+    keeps the earlier-seen one. ``test_ties_keep_earlier_seen`` above uses rows=1 and
+    never evicts, so it passes under either ordering and cannot catch this.
+    """
+    p1 = _page(
+        _item("a", "early", 500) + _item("b", "late", 500) + _item("c", "winner", 900),
+        next_page=None,
+    )
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        async with ClientSession() as session:
+            result = await scrape_dependents(session, BASE, rows=2, adaptive_stop=False)
+    assert [r.name for r in result.repos] == ["winner", "early"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_repos_counted_once() -> None:
+    p1 = _page(_item("a", "dup", 100), next_page=2)
+    p2 = _page(_item("a", "dup", 100) + _item("c", "new", 80), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        m.get("https://github.com/owner/repo/network/dependents?page=2", body=p2)
+        async with ClientSession() as session:
+            result = await scrape_dependents(
+                session, BASE, rows=10, token="ghp_x", adaptive_stop=False
+            )
+    assert result.matched_count == 2
+    assert sorted(r.name for r in result.repos) == ["dup", "new"]
+
+
+@pytest.mark.asyncio
+async def test_max_pages_reached_sets_reason() -> None:
+    """Hitting the page cap with more pages available -> complete=False, max_pages_reached."""
+    from dep_rank.core.models import ScrapeReason
+
+    p1 = _page(_item("a", "one", 100), next_page=2)
+    p2 = _page(_item("b", "two", 80), next_page=3)  # page 2 still advertises a next page
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        m.get("https://github.com/owner/repo/network/dependents?page=2", body=p2)
+        async with ClientSession() as session:
+            result = await scrape_dependents(
+                session, BASE, rows=5, max_pages=2, token="ghp_x", adaptive_stop=False
+            )
+    assert result.pages_scraped == 2
+    assert result.complete is False
+    assert result.reason == ScrapeReason.MAX_PAGES_REACHED
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_per_page_then_terminal() -> None:
+    p1 = _page(_item("a", "one", 100), next_page=2)
+    p2 = _page(_item("b", "two", 80), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        m.get("https://github.com/owner/repo/network/dependents?page=2", body=p2)
+        async with ClientSession() as session:
+            snaps = [
+                s
+                async for s in stream_dependents(
+                    session, BASE, rows=5, token="ghp_x", adaptive_stop=False
+                )
+            ]
+    assert [s.done for s in snaps] == [False, False, True]
+    assert snaps[-1].complete is True
+    assert snaps[-1].reason is None


### PR DESCRIPTION
## Summary

Phase 2 of the scraper-hardening effort (#74): replaces the "scrape-all-then-sort with a prefetch pipeline + module-level rate-limiter singletons" loop with a streaming async-generator built around a bounded top-K heap.

- **`stream_dependents(...) -> AsyncIterator[ScrapeSnapshot]`** is the new primitive — it walks dependents page by page, maintains a bounded min-heap of the top-`rows` repos, emits one `ScrapeSnapshot` per consumed page (`done=False`) plus exactly one terminal snapshot (`done=True`) carrying the authoritative `complete`/`reason`.
- **`scrape_dependents(...)`** becomes a thin compatibility wrapper that drains the generator into a `ScrapeResult`. Its defaults (`rows=None`, `max_pages=1000`) are deliberately unchanged, so the `deps`/`search` CLI keeps its existing result set **and** page budget — the CLI does not adopt the bounded 200-page primitive until Phase 4.
- **`ScrapeSnapshot`** model added for per-page emissions.
- **Typed scrape errors** (`ScrapeError`/`NetworkFailureError`/`RateLimitedError`) let the generator attach `reason="network_failure"`/`"rate_limited"`. `_fetch_page` now returns HTML or raises, runs through a bounded `Semaphore(concurrency)` + the Phase 1 `AdaptiveRateLimiter`, and `_read_page` preserves the fresh-cache fast-path (the seam Phase 3 hooks SWR into).
- **Adaptive early stop**: a trailing-window predicate (`W=20`, `W_min=30`) terminates with `reason="trend_converged"` once the saturated top-K can no longer plausibly change.
- The module-level rate-limiter singletons are removed; each scrape builds its own limiter (or uses an injected one). `search.py`'s own `SEARCH_RATE_LIMITER` is untouched.

`stream_dependents` is the new bounded entry point (200-page default); the CLI keeps the 1000-page wrapper default until Phase 4 wires `--max-pages`/`rows` through.

## Terminal contract (spec §2)

Every returned `ScrapeResult` satisfies `complete == (reason is None)` on all five exit paths: clean exhaustion (`reason=None`), `max_pages_reached`, `network_failure`, `rate_limited`, `trend_converged`. `matched_count` is now populated.

## Test Plan

- [x] `uv run pytest` — **161 passed, 93.98% coverage** (90% gate)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean; `mypy --strict` (pre-commit) clean
- [x] `grep -rn "_RATE_LIMITER_|TokenBucketRateLimiter" src/dep_rank/core/scraper.py` — empty (singletons removed)
- [x] New coverage: streaming top-K ordering + ties (admission **and** eviction) + dedup + `rows=0`/`rows>total` (`test_scraper_streaming.py`); adaptive-stop predicate + end-to-end early termination (`test_scraper_adaptive_stop.py`); bounded-concurrency fetch window (`test_scraper_concurrency.py`)
- [x] Backward-compat: `deps`/`search` CLI calls (`rows=None`, default `max_pages`) verified to keep the same result set and page budget; `MAX_PAGES` back-compat alias preserved

Spec: `docs/superpowers/specs/2026-05-30-scraper-hardening-design.md` §1 (streaming API + `rows` back-compat), §2 (terminal contract), §4 (adaptive stop), §5 (concurrency).

Refs #74.
