### PR TITLE
feat: scraper hardening phase 3 — stale-while-revalidate cache (#74)

### DIFF
--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -8,6 +8,7 @@ import itertools
 import logging
 import random
 import re
+import time
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -44,6 +45,11 @@ DEFAULT_CONCURRENCY = 3
 ADAPTIVE_WINDOW = 20  # trailing pages examined for the trend
 ADAPTIVE_W_MIN = 30  # minimum pages before adaptive stop may fire
 MAX_PAGES = MAX_PAGES_CEILING  # back-compat: cli.app's search progress bar imports this
+
+SWR_COOLDOWN = 300.0  # seconds a URL serves stale without re-refreshing after a failure
+SWR_DRAIN_TIMEOUT = 10.0  # seconds to await outstanding refreshes before cancelling
+SWR_HEADROOM_TOKENS = 2  # a background refresh consumes a token only when >= this many remain
+#                          (try_acquire reserve=SWR_HEADROOM_TOKENS-1, leaving >=1 for foreground)
 
 
 class ScrapeError(Exception):
@@ -237,6 +243,136 @@ async def _read_page(
             body: bytes = cached["body"]
             return body.decode("utf-8")
     return await _fetch_page(session, url, limiter, semaphore, auth_headers, cache)
+
+
+class SWRManager:
+    """Owns background stale-while-revalidate refreshes for one scrape.
+
+    Disabled when unauthenticated (refresh would displace the foreground walk under
+    the 1/min budget). Refreshes are deduped per URL, capped at one in flight,
+    suppressed while AIMD has concurrency at its floor, gated *at refresh time* on
+    foreground token headroom (via ``try_acquire(reserve=...)``), cooled down on
+    failure, and drained before the generator completes (while the session is still
+    open) — never at cache.close(). Refresh outcomes feed the shared limiter
+    (``note_success`` on 200/304, ``note_429`` on 429), so background rate pressure
+    throttles both background and foreground work.
+    """
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        limiter: AdaptiveRateLimiter,
+        auth_headers: dict[str, str],
+        cache: SqliteCache | None,
+        *,
+        enabled: bool,
+        cooldown: float = SWR_COOLDOWN,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._session = session
+        self._limiter = limiter
+        self._auth_headers = auth_headers
+        self._cache = cache
+        self._enabled = enabled and cache is not None
+        self._cooldown = cooldown
+        self._now = now
+        self._semaphore = asyncio.Semaphore(1)
+        self._inflight: set[str] = set()
+        self._cooldown_until: dict[str, float] = {}
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    def schedule(self, url: str) -> None:
+        """Schedule a background refresh if enabled, not deduped, off cooldown, and AIMD allows it.
+
+        Token headroom is deliberately **not** checked here. A schedule-time
+        ``tokens_available()`` read is lock-unaware and races the foreground walk
+        (tokens read here can be gone by the time the refresh runs). Instead the
+        token decision is made atomically at refresh time via
+        ``try_acquire(reserve=SWR_HEADROOM_TOKENS - 1)``, which both reserves
+        headroom for the foreground and consumes in one lock-aware step.
+        """
+        if not self._enabled or url in self._inflight:
+            return
+        until = self._cooldown_until.get(url)
+        if until is not None and self._now() < until:
+            return
+        if self._limiter.current_max_concurrency <= 1:
+            # AIMD has throttled concurrency to its floor on sustained 429s —
+            # suppress background work so it cannot compete with foreground retries.
+            return
+        self._inflight.add(url)
+        task = asyncio.create_task(self._refresh(url))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _refresh(self, url: str) -> None:
+        try:
+            async with self._semaphore:
+                # Atomically consume a token only if foreground headroom remains;
+                # if not (foreground drained the bucket), abort without making a request.
+                if not self._limiter.try_acquire(reserve=SWR_HEADROOM_TOKENS - 1):
+                    return
+                cached = await self._cache.get(url) if self._cache else None
+                headers = dict(self._auth_headers)
+                if cached and cached["etag"]:
+                    headers["If-None-Match"] = cached["etag"]
+                timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+                async with self._session.get(url, timeout=timeout, headers=headers) as resp:
+                    if resp.status == 200:
+                        self._limiter.note_success()
+                        body = await resp.read()
+                        if self._cache:
+                            await self._cache.put(
+                                url, body, etag=resp.headers.get("ETag"), ttl=CACHE_TTL
+                            )
+                    elif resp.status == 304 and cached and cached["body"] is not None:
+                        self._limiter.note_success()
+                        if self._cache:
+                            await self._cache.put(
+                                url, cached["body"], etag=cached["etag"], ttl=CACHE_TTL
+                            )
+                    elif resp.status == 429:
+                        # Feed the *shared* limiter so AIMD halves concurrency — which
+                        # suppresses further background refreshes (the schedule gate) and
+                        # lengthens foreground backoff. Mirrors the foreground 429 path in
+                        # `_fetch_page`. The returned delay is unused: the background path
+                        # waits via the per-URL cooldown below, not an in-band sleep.
+                        retry_after = resp.headers.get("Retry-After")
+                        self._limiter.note_429(float(retry_after) if retry_after else None)
+                        self._cooldown_until[url] = self._now() + self._cooldown
+                        logger.warning(
+                            "SWR refresh rate-limited (429) for %s; cooling down %.0fs",
+                            url,
+                            self._cooldown,
+                        )
+                    else:
+                        self._cooldown_until[url] = self._now() + self._cooldown
+                        logger.warning(
+                            "SWR refresh got unexpected status %d for %s; cooling down %.0fs",
+                            resp.status,
+                            url,
+                            self._cooldown,
+                        )
+        except (TimeoutError, aiohttp.ClientError) as exc:
+            self._cooldown_until[url] = self._now() + self._cooldown
+            logger.warning(
+                "SWR refresh failed for %s (%s); cooling down %.0fs",
+                url,
+                exc.__class__.__name__,
+                self._cooldown,
+            )
+        finally:
+            self._inflight.discard(url)
+
+    async def drain(self, timeout: float = SWR_DRAIN_TIMEOUT) -> None:
+        """Await outstanding refreshes up to ``timeout``, then cancel any stragglers."""
+        if not self._tasks:
+            return
+        _done, pending = await asyncio.wait(set(self._tasks), timeout=timeout)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
 
 def _heap_push(

--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -230,18 +230,18 @@ async def _read_page(
     semaphore: asyncio.Semaphore,
     auth_headers: dict[str, str],
     cache: SqliteCache | None,
+    swr: SWRManager | None = None,
 ) -> str:
-    """Return a page's HTML, skipping the network on a fresh cache hit.
-
-    Fresh hit -> cached body (no request). Expired-with-body or miss -> _fetch_page
-    (which revalidates via If-None-Match when an ETag is cached). Phase 3 extends the
-    expired branch with stale-while-revalidate.
-    """
+    """Return a page's HTML; fresh-hit skips network, stale-hit serves stale + refreshes."""
     if cache:
         cached = await cache.get(url)
-        if cached and cached["body"] is not None and not cached.get("expired"):
+        if cached and cached["body"] is not None:
             body: bytes = cached["body"]
-            return body.decode("utf-8")
+            if not cached.get("expired"):
+                return body.decode("utf-8")
+            if swr is not None:
+                swr.schedule(url)
+                return body.decode("utf-8")
     return await _fetch_page(session, url, limiter, semaphore, auth_headers, cache)
 
 
@@ -483,6 +483,8 @@ async def stream_dependents(
     semaphore = asyncio.Semaphore(concurrency)
     auth_headers: dict[str, str] = {"Authorization": f"token {token}"} if token else {}
 
+    swr = SWRManager(session, limiter, auth_headers, cache, enabled=bool(token))
+
     heap: list[tuple[int, int, Repository]] = []
     counter = itertools.count()
     seen: set[str] = set()
@@ -494,53 +496,58 @@ async def stream_dependents(
     page = 0
     reason: ScrapeReason | None = None
 
-    while current_url and page < max_pages:
-        try:
-            html = await _read_page(session, current_url, limiter, semaphore, auth_headers, cache)
-        except RateLimitedError:
-            reason = ScrapeReason.RATE_LIMITED
-            break
-        except NetworkFailureError:
-            reason = ScrapeReason.NETWORK_FAILURE
-            break
-        page += 1  # increment only after a page is actually consumed (spec §2)
+    try:
+        while current_url and page < max_pages:
+            try:
+                html = await _read_page(
+                    session, current_url, limiter, semaphore, auth_headers, cache, swr=swr
+                )
+            except RateLimitedError:
+                reason = ScrapeReason.RATE_LIMITED
+                break
+            except NetworkFailureError:
+                reason = ScrapeReason.NETWORK_FAILURE
+                break
+            page += 1  # increment only after a page is actually consumed (spec §2)
 
-        if page == 1:
-            counts = parse_dependent_counts(html)
-            est_deps = counts.get(dependent_type.value, 0)
-            est_pages = est_deps // DEPENDENTS_PER_PAGE if est_deps > 0 else 0
+            if page == 1:
+                counts = parse_dependent_counts(html)
+                est_deps = counts.get(dependent_type.value, 0)
+                est_pages = est_deps // DEPENDENTS_PER_PAGE if est_deps > 0 else 0
 
-        repos, next_url = parse_dependents_page(html)
-        page_max = 0
-        for repo_obj in repos:
-            if repo_obj.url in seen or repo_obj.url == source_url:
-                continue
-            if repo_obj.stars >= min_stars:
-                seen.add(repo_obj.url)
-                matched += 1
-                page_max = max(page_max, repo_obj.stars)
-                _heap_push(heap, repo_obj, next(counter), rows)
-        recent_max.append(page_max)
+            repos, next_url = parse_dependents_page(html)
+            page_max = 0
+            for repo_obj in repos:
+                if repo_obj.url in seen or repo_obj.url == source_url:
+                    continue
+                if repo_obj.stars >= min_stars:
+                    seen.add(repo_obj.url)
+                    matched += 1
+                    page_max = max(page_max, repo_obj.stars)
+                    _heap_push(heap, repo_obj, next(counter), rows)
+            recent_max.append(page_max)
 
-        if on_progress:
-            await on_progress(page, est_pages)
-        yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=False)
+            if on_progress:
+                await on_progress(page, est_pages)
+            yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=False)
 
-        if adaptive_stop and bounded and _should_stop(heap, rows, recent_max, page):
-            reason = ScrapeReason.TREND_CONVERGED
-            break
-        current_url = next_url
-    else:
-        # Loop exited via its condition (no break): exhausted, unless we stopped at the cap.
-        if current_url is not None and page >= max_pages:
-            reason = ScrapeReason.MAX_PAGES_REACHED
+            if adaptive_stop and bounded and _should_stop(heap, rows, recent_max, page):
+                reason = ScrapeReason.TREND_CONVERGED
+                break
+            current_url = next_url
+        else:
+            # Loop exited via its condition (no break): exhausted, unless we stopped at the cap.
+            if current_url is not None and page >= max_pages:
+                reason = ScrapeReason.MAX_PAGES_REACHED
 
-    # `estimated_total_pages` is always the header-derived estimate (`est_pages`),
-    # matching the historical scraper (it returned the header estimate unconditionally).
-    # Actual pages consumed live in `pages_scraped`; do NOT overwrite the estimate with
-    # `page` on completion — Phase 4 summaries and existing header-estimate tests depend
-    # on the estimate staying the population projection, not the walked count.
-    yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=True, reason=reason)
+        # `estimated_total_pages` is always the header-derived estimate (`est_pages`),
+        # matching the historical scraper (it returned the header estimate unconditionally).
+        # Actual pages consumed live in `pages_scraped`; do NOT overwrite the estimate with
+        # `page` on completion — Phase 4 summaries and existing header-estimate tests depend
+        # on the estimate staying the population projection, not the walked count.
+        yield _build_snapshot(heap, page, est_pages, est_deps, matched, done=True, reason=reason)
+    finally:
+        await swr.drain()
 
 
 async def scrape_dependents(

--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -232,7 +232,13 @@ async def _read_page(
     cache: SqliteCache | None,
     swr: SWRManager | None = None,
 ) -> str:
-    """Return a page's HTML; fresh-hit skips network, stale-hit serves stale + refreshes."""
+    """Return a page's HTML; fresh-hit skips network, stale-hit serves stale + refreshes.
+
+    Fresh cache hit -> cached body (no request). Expired-with-body + an ``swr`` manager ->
+    serve stale immediately and schedule a background revalidation (Phase 3 SWR). Miss,
+    expired-without-``swr`` -> ``_fetch_page`` (revalidates via If-None-Match when an ETag
+    is cached).
+    """
     if cache:
         cached = await cache.get(url)
         if cached and cached["body"] is not None:
@@ -469,6 +475,10 @@ async def stream_dependents(
     Yields one snapshot per consumed page (done=False) then exactly one terminal
     snapshot (done=True) carrying complete/reason. ``rows is None`` keeps every
     matched repo and disables adaptive stop (back-compat for the wrapper).
+
+    Callers must fully iterate this generator (no early ``break``); the ``finally``
+    block awaits outstanding background SWR refreshes before completion, so abandoning
+    iteration early could let the session close while a refresh is still in flight.
     """
     if not 1 <= concurrency <= 10:
         msg = f"concurrency must be between 1 and 10, got {concurrency}"

--- a/tests/core/test_cache_swr.py
+++ b/tests/core/test_cache_swr.py
@@ -1,0 +1,186 @@
+"""Tests for stale-while-revalidate background refresh."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from dep_rank.core.cache import SqliteCache
+from dep_rank.core.rate_limiter import AdaptiveRateLimiter
+from dep_rank.core.scraper import SWRManager
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: bytes = b"", etag: str | None = None, delay: float = 0.0):
+        self.status = status
+        self._body = body
+        self.headers: dict[str, str] = {"ETag": etag} if etag else {}
+        self._delay = delay
+
+    async def __aenter__(self) -> _FakeResp:
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    """Returns queued responses per call; records how many GETs happened."""
+
+    def __init__(self, responses: list[_FakeResp]):
+        self._responses = responses
+        self.calls = 0
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResp:  # noqa: ARG002
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+def _auth_limiter() -> AdaptiveRateLimiter:
+    return AdaptiveRateLimiter(60, 60.0, 3)
+
+
+async def _seed_expired(cache: SqliteCache, url: str, body: bytes, etag: str) -> None:
+    await cache.put(url, body, etag=etag, ttl=-1)  # already expired
+
+
+@pytest.fixture
+async def cache(tmp_path: Any) -> SqliteCache:
+    c = SqliteCache(str(tmp_path))
+    await c.initialize()
+    return c
+
+
+URL = "https://github.com/o/r/network/dependents?page=5"
+
+
+class TestSWRManager:
+    @pytest.mark.asyncio
+    async def test_disabled_when_unauthenticated(self, cache: SqliteCache) -> None:
+        session = _FakeSession([])
+        swr = SWRManager(session, _auth_limiter(), {}, cache, enabled=False)
+        swr.schedule(URL)
+        await swr.drain()
+        assert session.calls == 0  # no refresh ever scheduled
+
+    @pytest.mark.asyncio
+    async def test_refresh_updates_cache_on_200(self, cache: SqliteCache) -> None:
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        session = _FakeSession([_FakeResp(200, body=b"fresh", etag='"new"')])
+        swr = SWRManager(session, _auth_limiter(), {}, cache, enabled=True)
+        swr.schedule(URL)
+        await swr.drain()
+        entry = await cache.get(URL)
+        assert entry is not None
+        assert entry["body"] == b"fresh"
+        assert entry["expired"] is False
+
+    @pytest.mark.asyncio
+    async def test_429_feeds_aimd_then_suppresses(self, cache: SqliteCache) -> None:
+        """A background 429 must update the shared limiter (AIMD halves concurrency),
+        leave the stale body intact, and — once concurrency hits the floor — suppress
+        further background refreshes."""
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        limiter = AdaptiveRateLimiter(60, 60.0, concurrency=2, jitter=False)
+        assert limiter.current_max_concurrency == 2
+        resp = _FakeResp(429)
+        resp.headers["Retry-After"] = "30"
+        session = _FakeSession([resp])
+        swr = SWRManager(session, limiter, {}, cache, enabled=True)
+        swr.schedule(URL)
+        await swr.drain()
+        assert session.calls == 1
+        # AIMD consumed the background 429: 2 -> 1.
+        assert limiter.current_max_concurrency == 1
+        # The 429 did not overwrite the cached stale body.
+        entry = await cache.get(URL)
+        assert entry is not None and entry["body"] == b"stale"
+        # With concurrency at the floor, a fresh URL's refresh is now suppressed —
+        # if it were not, _FakeSession.get would pop an empty queue and raise.
+        other = URL + "&x=2"
+        await _seed_expired(cache, other, b"stale2", '"old2"')
+        swr.schedule(other)
+        await swr.drain()
+        assert session.calls == 1  # no new request fired
+
+    @pytest.mark.asyncio
+    async def test_dedup_one_refresh_per_url(self, cache: SqliteCache) -> None:
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        session = _FakeSession([_FakeResp(200, body=b"fresh", etag='"new"', delay=0.02)])
+        swr = SWRManager(session, _auth_limiter(), {}, cache, enabled=True)
+        swr.schedule(URL)
+        swr.schedule(URL)  # second call must be a no-op (already in flight)
+        await swr.drain()
+        assert session.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_refresh_enters_cooldown(
+        self, cache: SqliteCache, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        clock = {"t": 0.0}
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        session = _FakeSession([_FakeResp(500)])  # one failing response only
+        swr = SWRManager(
+            session,
+            _auth_limiter(),
+            {},
+            cache,
+            enabled=True,
+            now=lambda: clock["t"],
+        )
+        with caplog.at_level(logging.WARNING, logger="dep_rank.core.scraper"):
+            swr.schedule(URL)
+            await swr.drain()
+        assert session.calls == 1  # failed once
+        # The failure is surfaced at WARNING (spec §3 "Logged at WARNING; silent to user").
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+        # within cooldown: a second schedule must NOT fire another request
+        swr.schedule(URL)
+        await swr.drain()
+        assert session.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_no_refresh_without_foreground_headroom(self, cache: SqliteCache) -> None:
+        """Spec §3 foreground-priority: at low headroom the refresh makes no request AND
+        a concurrent foreground ``acquire()`` is not delayed by the refresh path."""
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        limiter = AdaptiveRateLimiter(60, 60.0, 3)
+        # Drain to exactly 1 token: below SWR headroom (a refresh needs >=2 via
+        # try_acquire(reserve=1)) but the foreground can still take its single token.
+        while limiter.tokens_available() >= 2:
+            limiter.try_acquire()
+        session = _FakeSession([_FakeResp(200, body=b"fresh", etag='"new"')])
+        swr = SWRManager(session, limiter, {}, cache, enabled=True)
+
+        # Run the background refresh and a foreground acquire concurrently. The refresh
+        # must abort (no request); the foreground acquire must complete promptly rather
+        # than blocking on a token the refresh grabbed or a 60s bucket sleep. If the
+        # foreground were starved, wait_for would raise TimeoutError well before 60s.
+        swr.schedule(URL)
+        foreground = asyncio.create_task(limiter.acquire())
+        await asyncio.wait_for(asyncio.gather(swr.drain(), foreground), timeout=1.0)
+
+        assert session.calls == 0  # refresh aborted: try_acquire(reserve=1) saw <2 tokens
+        assert foreground.done()  # foreground acquired immediately, never queued behind SWR
+
+    @pytest.mark.asyncio
+    async def test_drain_cancels_stragglers_past_timeout(self, cache: SqliteCache) -> None:
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        session = _FakeSession([_FakeResp(200, body=b"fresh", etag='"new"', delay=5.0)])
+        swr = SWRManager(session, _auth_limiter(), {}, cache, enabled=True)
+        swr.schedule(URL)
+        # Drain with a tiny timeout: must return promptly, cancelling the slow refresh.
+        await swr.drain(timeout=0.05)
+        # Cache still holds the stale body (refresh was cancelled before writing).
+        entry = await cache.get(URL)
+        assert entry is not None
+        assert entry["body"] == b"stale"

--- a/tests/core/test_cache_swr.py
+++ b/tests/core/test_cache_swr.py
@@ -198,3 +198,91 @@ class TestSWRManager:
         entry = await cache.get(URL)
         assert entry is not None
         assert entry["body"] == b"stale"
+
+
+class TestSWRIntegration:
+    @pytest.mark.asyncio
+    async def test_read_page_serves_stale_and_schedules_refresh(self, cache: SqliteCache) -> None:
+        from dep_rank.core.scraper import _read_page
+
+        await _seed_expired(cache, URL, b"<html>stale</html>", '"old"')
+        session = _FakeSession([_FakeResp(200, body=b"<html>fresh</html>", etag='"new"')])
+        limiter = _auth_limiter()
+        swr = SWRManager(session, limiter, {}, cache, enabled=True)
+        import asyncio as _asyncio
+
+        html = await _read_page(
+            session,
+            URL,
+            limiter,
+            _asyncio.Semaphore(3),
+            {},
+            cache,
+            swr=swr,
+        )
+        assert html == "<html>stale</html>"  # stale served synchronously
+        await swr.drain()
+        entry = await cache.get(URL)
+        assert entry is not None
+        assert entry["body"] == b"<html>fresh</html>"  # refreshed in background
+
+    @pytest.mark.asyncio
+    async def test_stream_blocks_on_drain_before_returning(self, tmp_path: Any) -> None:
+        """`stream_dependents` must AWAIT `swr.drain()` in its finally *before returning* —
+        not leave the refresh as a fire-and-forget task that merely happens to finish in
+        time.
+
+        The trap this avoids: with an immediate refresh response, the task can complete
+        opportunistically while the wrapper is still consuming snapshots, so a "is the
+        entry refreshed by the time scrape returns?" assertion passes *even if the
+        generator never drained*. So we make completion-without-drain impossible: the
+        background refresh response is **delayed**, while the foreground walk is a single
+        stale cache-hit (no foreground fetch) that would return near-instantly on its own.
+
+        - If the generator drains: the scrape return is BLOCKED until the delayed 304 lands
+          and bumps the TTL, so the entry is no longer expired when scrape returns.
+        - If it does NOT drain: scrape returns while the refresh is still mid-delay, the
+          entry is still expired, and this test fails — catching the exact lifecycle bug
+          (refresh deferred past the caller's `async with session` exit) the design fixes.
+        """
+        from dep_rank.core.scraper import scrape_dependents
+
+        cache = SqliteCache(str(tmp_path))
+        await cache.initialize()
+        first = "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY"
+        stale = (
+            '<html><body><div class="table-list-header-toggle states flex-auto pl-0">'
+            '<a class="btn-link selected" '
+            'href="/owner/repo/network/dependents?dependent_type=REPOSITORY">30 Repositories</a>'
+            '</div><div id="dependents"><div class="Box">'
+            '<div class="flex-items-center"><span>'
+            '<a class="text-bold" href="/a/one">a/one</a></span><div><span>100</span></div></div>'
+            '</div><div class="paginate-container"><div>'
+            '<a href="/owner/repo/network/dependents?page=0">Previous</a></div></div></div>'
+            "</body></html>"
+        )
+        await cache.put(first, stale.encode(), etag='"old"', ttl=-1)  # expired
+        # Page 1 is served from the stale cache (no foreground fetch), so the ONLY
+        # session.get() is the delayed background refresh. The 0.3s delay (< the 10s drain
+        # timeout, so it is not cancelled) is what makes "completed by return" equivalent
+        # to "return was blocked on drain": on a single event loop the fast foreground walk
+        # cannot outrun a still-sleeping refresh task.
+        session = _FakeSession([_FakeResp(304, delay=0.3)])
+        try:
+            result = await scrape_dependents(
+                session,
+                "https://github.com/owner/repo",
+                rows=5,
+                token="ghp_x",
+                cache=cache,
+            )
+            assert result.complete is True
+            assert [r.name for r in result.repos] == ["one"]
+            assert session.calls == 1  # the background refresh actually ran
+            # Refreshed-by-return is only possible if the return blocked on drain; a
+            # fire-and-forget task would still be mid-delay at this point.
+            refreshed = await cache.get(first)
+            assert refreshed is not None
+            assert refreshed["expired"] is False
+        finally:
+            await cache.close()

--- a/tests/core/test_cache_swr.py
+++ b/tests/core/test_cache_swr.py
@@ -83,6 +83,20 @@ class TestSWRManager:
         assert entry["expired"] is False
 
     @pytest.mark.asyncio
+    async def test_refresh_bumps_ttl_on_304(self, cache: SqliteCache) -> None:
+        """A 304 revalidation keeps the stale body but refreshes its TTL (no longer expired)."""
+        await _seed_expired(cache, URL, b"stale", '"old"')
+        session = _FakeSession([_FakeResp(304)])
+        swr = SWRManager(session, _auth_limiter(), {}, cache, enabled=True)
+        swr.schedule(URL)
+        await swr.drain()
+        assert session.calls == 1
+        entry = await cache.get(URL)
+        assert entry is not None
+        assert entry["body"] == b"stale"  # body unchanged on 304
+        assert entry["expired"] is False  # TTL bumped
+
+    @pytest.mark.asyncio
     async def test_429_feeds_aimd_then_suppresses(self, cache: SqliteCache) -> None:
         """A background 429 must update the shared limiter (AIMD halves concurrency),
         leave the stale body intact, and — once concurrency hits the floor — suppress

--- a/tests/core/test_cache_swr.py
+++ b/tests/core/test_cache_swr.py
@@ -209,13 +209,11 @@ class TestSWRIntegration:
         session = _FakeSession([_FakeResp(200, body=b"<html>fresh</html>", etag='"new"')])
         limiter = _auth_limiter()
         swr = SWRManager(session, limiter, {}, cache, enabled=True)
-        import asyncio as _asyncio
-
         html = await _read_page(
             session,
             URL,
             limiter,
-            _asyncio.Semaphore(3),
+            asyncio.Semaphore(3),
             {},
             cache,
             swr=swr,


### PR DESCRIPTION
## Summary

Phase 3 of the scraper-hardening effort (#74): adds **stale-while-revalidate (SWR)** caching. Expired-but-present cached pages are served immediately while their ETags are revalidated in the background, so a second run on a slowly-changing repo returns the prior run's pages instantly and refreshes them out of band.

- **`SWRManager`** (new, in `scraper.py` next to `_read_page`/`_fetch_page`, which it reuses) owns background refreshes for one scrape: deduped per URL, capped at one in flight via `Semaphore(1)`, suppressed while AIMD has concurrency at its floor, gated on foreground token headroom **at refresh time** via `try_acquire(reserve=SWR_HEADROOM_TOKENS - 1)` (no lock-unaware schedule-time token read), cooled down 300s on failure, and drained (bounded 10s timeout, cancelling stragglers) inside `stream_dependents`'s `finally` — **before the generator completes, while the aiohttp session is still open**, never at `cache.close()`.
- **`_read_page`** gains an optional `swr` param: on an expired-with-body cache hit it serves the stale body synchronously and calls `swr.schedule(url)`; fresh hits and misses are byte-for-byte unchanged.
- Refresh outcomes feed the **shared** `AdaptiveRateLimiter` (`note_success` on 200/304, `note_429` on 429), so background rate pressure throttles both lanes (spec §3). A background 429 halves concurrency, which in turn suppresses further background refreshes.
- **Disabled when unauthenticated** (`enabled=bool(token)`): under the 1/min budget a refresh would displace the foreground walk, so stale is served but never refreshed in-band.

`stream_dependents` constructs one manager per scrape and drains it in `finally`; the `scrape_dependents` wrapper and CLI behavior are unchanged.

## Lifecycle contract (spec §3)

The drain lives in `stream_dependents`'s `finally`, not in `cache.close()` — `app.py` has no SWR logic. Because the wrapper fully iterates the generator, the drain runs before the wrapper returns → before `async with session` exits → before `cache.close()`. `test_stream_blocks_on_drain_before_returning` proves this with a *delayed* 304: the scrape return is provably blocked on `drain()` (removing `await swr.drain()` fails the test with a closed-DB error), not merely "the refresh happened to finish in time."

## Test Plan

- [x] `uv run pytest` — **171 passed, 94.02% coverage** (90% gate); no "Task was destroyed but it is pending" warnings (verified, incl. under `-W error::RuntimeWarning`)
- [x] `uv run ruff check src tests` + `ruff format --check` — clean; `mypy --strict` — clean (13 files)
- [x] New coverage (`tests/core/test_cache_swr.py`, 10 tests): unauth-disabled; 200/304 cache update; 429 → AIMD halve + suppress + stale preserved; per-URL dedup; failure → 300s cooldown + WARNING; foreground-priority (no refresh at low headroom + foreground `acquire()` not delayed); bounded-drain straggler cancellation; `_read_page` serve-stale-and-schedule; drain-before-return lifecycle (delayed 304)
- [x] Backward-compat: all Phase 1/2 tests pass unchanged (fresh-hit/miss read paths preserved; `matched_count`/`complete`/`reason` derivation untouched)

Spec: `docs/superpowers/specs/2026-05-30-scraper-hardening-design.md` §3 (SWR contract, lifecycle, foreground priority), §5 (`try_acquire`).

## Notes for reviewers

- Within a single run SWR rarely triggers (each page is read once); the win is **cross-invocation**.
- Pre-existing follow-up (out of scope, deferred to Phase 4): `cache.py`'s `get()` docstring says expired entries return `{"body": None}`, but the code returns the real body — which is exactly what SWR relies on. The docstring is now misleading and worth a cleanup.

Refs #74.
