### PR TITLE
feat: scraper hardening phase 4 — CLI flags, docs, and drift CI (#74)

### DIFF
--- a/.github/workflows/scraper-drift-check.yml
+++ b/.github/workflows/scraper-drift-check.yml
@@ -1,0 +1,20 @@
+name: Scraper Drift Check
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-uv  # installs uv + runs `uv sync --locked`
+      - name: Run drift check
+        env:
+          DRIFT_CHECK_TOKEN: ${{ secrets.DRIFT_CHECK_TOKEN }}
+        run: uv run python -m dep_rank.scripts.drift_check

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ dep-rank deps https://github.com/django/django --packages
 | `--descriptions` | off | Fetch descriptions via GitHub API (requires token) |
 | `--packages` | off | Search packages instead of repositories |
 | `--token` | `DEP_RANK_TOKEN` | GitHub token |
+| `--max-pages` | 200 | Maximum pages to scrape (ceiling 1000) |
+| `--concurrency` | 3 | Max concurrent page fetches (1–10) |
+| `--no-adaptive-stop` | off | Disable adaptive early-stop; scrape continues until exhaustion or `--max-pages` |
 
 ### `dep-rank search` — Search code in dependents
 
@@ -47,6 +50,14 @@ dep-rank search https://github.com/django/django "middleware" --max-repos 20
 | `--max-repos` | 10 | Maximum repos to search |
 | `--min-stars` | 50 | Only search repos with this many stars |
 | `--token` | `DEP_RANK_TOKEN` | GitHub token (required) |
+| `--max-pages` | 200 | Maximum pages to scrape (ceiling 1000) |
+| `--concurrency` | 3 | Max concurrent page fetches (1–10) |
+
+`search` always runs a bounded non-adaptive top-K scrape (`--no-adaptive-stop` is not exposed; adaptive early-stop is permanently disabled for this command).
+
+### Partial results
+
+A scrape result (`deps`, and the `search` pre-pass) reports whether it finished: results include a `complete` flag and a `reason`. `complete: false` means the scrape stopped early — `max_pages_reached` (raise `--max-pages`), `trend_converged` (the adaptive heuristic judged the top-K stable; use `--no-adaptive-stop` to scrape until exhaustion or `--max-pages`), `network_failure`, or `rate_limited`. `total_count`/`filtered_count` are then lower bounds across the pages actually scraped, not population totals.
 
 ### `dep-rank cache` — Manage cache
 
@@ -62,6 +73,8 @@ Set the `DEP_RANK_TOKEN` environment variable with a GitHub personal access toke
 ```bash
 export DEP_RANK_TOKEN=ghp_your_token_here
 ```
+
+A token is effectively required for non-trivial use: unauthenticated GitHub HTML scraping is limited to ~60 requests/hour per IP, so unauthenticated runs are suitable only for small one-off scrapes. Set `DEP_RANK_TOKEN` to raise the limit.
 
 **What works without a token:**
 - `dep-rank deps` — core scraping and star ranking
@@ -80,7 +93,7 @@ dep-rank uses a three-stage pipeline:
 2. **Enrich** (optional) — one GraphQL batch query fetches accurate star counts and descriptions for the top N results (replaces 100 individual REST API calls)
 3. **Present** — returns structured results as a Rich table
 
-Responses are cached in a local SQLite database (`~/.cache/dep-rank/`) with ETag support for conditional requests.
+Responses are cached in a local SQLite database (`~/.cache/dep-rank/`) with ETag support for conditional requests. Expired pages are served immediately and refreshed in the background (stale-while-revalidate) on authenticated runs.
 
 ## Development
 

--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -255,9 +255,27 @@ def deps(
 @click.option("--max-repos", default=10, help="Maximum repos to search.")
 @click.option("--min-stars", default=50, help="Only search repos with this many stars.")
 @click.option("--token", envvar="DEP_RANK_TOKEN", required=True, help="GitHub token (required).")
+@click.option(
+    "--max-pages",
+    default=200,
+    help="Maximum pages to scrape (default: 200, ceiling 1000).",
+)
+@click.option(
+    "--concurrency",
+    type=click.IntRange(1, 10),
+    default=3,
+    help="Max concurrent page fetches (1-10, default: 3).",
+)
 @click.pass_context
 def search(
-    ctx: click.Context, url: str, query: str, max_repos: int, min_stars: int, token: str
+    ctx: click.Context,
+    url: str,
+    query: str,
+    max_repos: int,
+    min_stars: int,
+    token: str,
+    max_pages: int,
+    concurrency: int,
 ) -> None:
     """Search code patterns across dependents of a GitHub repository."""
     try:
@@ -265,6 +283,10 @@ def search(
     except ValueError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
+
+    if max_pages > 1000:
+        click.echo("Warning: --max-pages capped at the 1000 ceiling.", err=True)
+        max_pages = 1000
 
     verbose = ctx.obj.get("verbose", False)
 
@@ -289,7 +311,6 @@ def search(
                 from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
 
                 from dep_rank.cli.formatters import format_scrape_summary
-                from dep_rank.core.scraper import MAX_PAGES
 
                 progress_ctx = None
                 task_id = None
@@ -306,7 +327,7 @@ def search(
                         console=console,
                     )
                     task_id = progress_ctx.add_task(
-                        "scraping", total=MAX_PAGES, est_text="estimating..."
+                        "scraping", total=max_pages, est_text="estimating..."
                     )
 
                 async def on_progress(page: int, est_total: int) -> None:
@@ -328,6 +349,10 @@ def search(
                         cache=cache,
                         on_progress=on_progress,
                         token=token,
+                        max_pages=max_pages,
+                        rows=max_repos,
+                        concurrency=concurrency,
+                        adaptive_stop=False,
                     )
                 finally:
                     if progress_ctx is not None:
@@ -338,10 +363,14 @@ def search(
                     pages_scraped=scrape_result.pages_scraped,
                     max_pages=scrape_result.max_pages,
                     estimated_total_pages=scrape_result.estimated_total_pages,
-                    found_count=len(repos),
+                    found_count=scrape_result.matched_count,
                     min_stars=min_stars,
                 )
                 console.print(f"[green]{summary}")
+                if not scrape_result.complete:
+                    from dep_rank.cli.formatters import partial_warning
+
+                    console.print(partial_warning(scrape_result.reason))
 
                 result = await search_code(
                     session,

--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -30,7 +30,10 @@ async def run_deps(
     packages: bool,
     token: str | None,
     verbose: bool = False,
-    max_pages: int = 1000,
+    max_pages: int = 200,
+    concurrency: int = 3,
+    adaptive_stop: bool = True,
+    quiet: bool = False,
 ) -> DependentsResult:
     """Run the deps pipeline: scrape → enrich → return."""
     import aiohttp
@@ -55,7 +58,7 @@ async def run_deps(
         ) as session:
             progress_ctx = None
             task_id = None
-            if not verbose:
+            if not verbose and not quiet:
                 progress_ctx = Progress(
                     TextColumn("[bold green]Scraping dependents..."),
                     BarColumn(),
@@ -90,22 +93,30 @@ async def run_deps(
                     on_progress=on_progress,
                     token=token,
                     max_pages=max_pages,
+                    rows=rows,
+                    concurrency=concurrency,
+                    adaptive_stop=adaptive_stop,
                 )
             finally:
                 if progress_ctx is not None:
                     progress_ctx.stop()
 
             repos = scrape_result.repos
-            total_count = len(repos)
+            total_count = scrape_result.matched_count
 
-            summary = format_scrape_summary(
-                pages_scraped=scrape_result.pages_scraped,
-                max_pages=scrape_result.max_pages,
-                estimated_total_pages=scrape_result.estimated_total_pages,
-                found_count=total_count,
-                min_stars=min_stars,
-            )
-            console.print(f"[green]{summary}")
+            if not quiet:
+                summary = format_scrape_summary(
+                    pages_scraped=scrape_result.pages_scraped,
+                    max_pages=scrape_result.max_pages,
+                    estimated_total_pages=scrape_result.estimated_total_pages,
+                    found_count=total_count,
+                    min_stars=min_stars,
+                )
+                console.print(f"[green]{summary}")
+                if not scrape_result.complete:
+                    from dep_rank.cli.formatters import partial_warning
+
+                    console.print(partial_warning(scrape_result.reason))
 
             repos = repos[:rows]
 
@@ -120,6 +131,10 @@ async def run_deps(
                 repos=repos,
                 dependent_type=dep_type,
                 scraped_at=datetime.now(tz=UTC),
+                complete=scrape_result.complete,
+                reason=scrape_result.reason,
+                pages_scraped=scrape_result.pages_scraped,
+                estimated_total_pages=scrape_result.estimated_total_pages,
             )
     finally:
         await cache.close()
@@ -155,7 +170,20 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     "--packages/--repositories", default=False, help="Search packages instead of repositories."
 )
 @click.option("--token", envvar="DEP_RANK_TOKEN", default=None, help="GitHub token.")
-@click.option("--max-pages", default=1000, help="Maximum pages to scrape (default: 1000).")
+@click.option(
+    "--max-pages", default=200, help="Maximum pages to scrape (default: 200, ceiling 1000)."
+)
+@click.option(
+    "--concurrency",
+    type=click.IntRange(1, 10),
+    default=3,
+    help="Max concurrent page fetches (1-10, default: 3).",
+)
+@click.option(
+    "--adaptive-stop/--no-adaptive-stop",
+    default=True,
+    help="Stop early when recent pages can no longer change the top-K (default: on).",
+)
 @click.pass_context
 def deps(
     ctx: click.Context,
@@ -167,6 +195,8 @@ def deps(
     packages: bool,
     token: str | None,
     max_pages: int,
+    concurrency: int,
+    adaptive_stop: bool,
 ) -> None:
     """List top dependents of a GitHub repository, ranked by stars."""
     try:
@@ -182,9 +212,33 @@ def deps(
         )
         sys.exit(1)
 
+    if max_pages > 1000:
+        click.echo("Warning: --max-pages capped at the 1000 ceiling.", err=True)
+        max_pages = 1000
+
+    if not token:
+        click.echo(
+            "Warning: no GitHub token configured (--token or DEP_RANK_TOKEN). "
+            "Unauthenticated scraping is limited to ~60 requests/hour; "
+            "large repositories will be slow or return partial results.",
+            err=True,
+        )
+
     verbose = ctx.obj.get("verbose", False)
     result = asyncio.run(
-        run_deps(url, rows, min_stars, descriptions, packages, token, verbose, max_pages)
+        run_deps(
+            url,
+            rows,
+            min_stars,
+            descriptions,
+            packages,
+            token,
+            verbose,
+            max_pages=max_pages,
+            concurrency=concurrency,
+            adaptive_stop=adaptive_stop,
+            quiet=(output_format == "json"),
+        )
     )
 
     from dep_rank.cli.formatters import print_dependents_json, print_dependents_table

--- a/src/dep_rank/cli/formatters.py
+++ b/src/dep_rank/cli/formatters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
-from dep_rank.core.models import CodeSearchResult, DependentsResult
+from dep_rank.core.models import CodeSearchResult, DependentsResult, ScrapeReason
 
 console = Console()
 
@@ -71,6 +71,26 @@ def print_search_results(result: CodeSearchResult) -> None:
 
     console.print(table)
     console.print(f"\n[dim]Searched {result.searched_repos} repositories[/dim]")
+
+
+def partial_warning(reason: ScrapeReason | None) -> str:
+    """Render a one-line caveat explaining why a result is partial."""
+    messages = {
+        ScrapeReason.MAX_PAGES_REACHED: (
+            "Stopped at the page cap — results are a partial top-K. "
+            "Raise --max-pages (ceiling 1000) for deeper coverage."
+        ),
+        ScrapeReason.TREND_CONVERGED: (
+            "Stopped early — the adaptive heuristic judged the top-K stable. "
+            "Use --no-adaptive-stop to scrape until exhaustion or the --max-pages cap."
+        ),
+        ScrapeReason.NETWORK_FAILURE: ("Scrape ended on a network error — results are partial."),
+        ScrapeReason.RATE_LIMITED: (
+            "Scrape ended on rate limiting — results are partial. A GitHub token raises the limit."
+        ),
+    }
+    text = messages.get(reason, "Results are partial.") if reason else "Results are partial."
+    return f"[yellow]⚠ {text}[/yellow]"
 
 
 def format_scrape_summary(

--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -84,6 +84,17 @@ class DependentsResult(BaseModel):
     repos: list[Repository]
     dependent_type: DependentType
     scraped_at: datetime
+    complete: bool = True
+    reason: ScrapeReason | None = None
+    pages_scraped: int = 0
+    estimated_total_pages: int = 0
+
+    @model_validator(mode="after")
+    def _check_complete_reason_invariant(self) -> DependentsResult:
+        if self.complete != (self.reason is None):
+            msg = "DependentsResult invariant violated: complete must equal (reason is None)"
+            raise ValueError(msg)
+        return self
 
 
 class CodeSearchHit(BaseModel):

--- a/src/dep_rank/scripts/drift_check.py
+++ b/src/dep_rank/scripts/drift_check.py
@@ -1,0 +1,111 @@
+"""Weekly canary: verify GitHub dependents selectors still parse a known repo.
+
+Run via ``uv run python -m dep_rank.scripts.drift_check``. Requires the
+``DRIFT_CHECK_TOKEN`` env var (a fine-grained read-only PAT); without it the script
+exits 2 rather than running unauthenticated and risking a permanently-blind green check.
+
+Exit codes:
+  0 — selectors healthy, or transient/inconclusive run (emits a ``::warning::`` annotation)
+  1 — drift detected: item selectors returned no repos, or the header count parsed to zero
+  2 — misconfigured: ``DRIFT_CHECK_TOKEN`` not set
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import aiohttp
+
+from dep_rank.core.models import ScrapeReason
+from dep_rank.core.scraper import scrape_dependents
+
+# Transport-level stop reasons mean we could not observe enough HTML to judge selector
+# health — they are *inconclusive*, never "drift". Selector/header drift is only a valid
+# verdict when the scrape actually reached pages (reason None or MAX_PAGES_REACHED).
+_INCONCLUSIVE_REASONS = (ScrapeReason.NETWORK_FAILURE, ScrapeReason.RATE_LIMITED)
+
+CANARY_URL = "https://github.com/pallets/flask"
+# min_stars=0 so the canary measures *raw selector health*, not the star filter: any
+# parsed dependent proves the item selectors still match GitHub's HTML. A higher
+# threshold could legitimately yield zero matches on a healthy page (the first pages
+# may list low-star dependents) and false-alarm as "selector drift".
+CANARY_MIN_STARS = 0
+CANARY_MAX_PAGES = 2
+
+
+def evaluate_drift(
+    repos_count: int,
+    total_dependents: int,
+    reason: ScrapeReason | None = None,
+) -> list[str]:
+    """Return a list of human-readable drift problems (empty == healthy).
+
+    A transport-level ``reason`` (``NETWORK_FAILURE``/``RATE_LIMITED``) is *inconclusive*:
+    we never saw enough HTML to judge the selectors, so we return ``[]`` rather than
+    misreporting a flaky network as selector drift. ``MAX_PAGES_REACHED`` and
+    ``TREND_CONVERGED`` are expected on the canary and do not suppress evaluation — the
+    pages actually scraped still prove the selectors parse.
+    """
+    if reason in _INCONCLUSIVE_REASONS:
+        return []
+    problems: list[str] = []
+    if repos_count <= 0:
+        problems.append("item selectors returned zero repositories")
+    if total_dependents <= 0:
+        problems.append("dependents-count header parsed to zero")
+    return problems
+
+
+async def _run() -> int:
+    token = os.environ.get("DRIFT_CHECK_TOKEN")
+    if not token:
+        # Fail loudly on a missing token instead of running unauthenticated. An unauth
+        # canary is the silent-blind failure mode: GitHub is far likelier to 429 it, the
+        # scrape ends RATE_LIMITED, the run exits 0 "inconclusive", and the check passes
+        # every week without ever verifying a selector. A red job is the correct prompt to
+        # add the DRIFT_CHECK_TOKEN secret (see spec §7 "authenticated via DRIFT_CHECK_TOKEN").
+        sys.stderr.write(
+            "::error::DRIFT_CHECK_TOKEN is not set. The drift canary requires an "
+            "authenticated token to run reliably; add the repo secret.\n"
+        )
+        return 2
+    async with aiohttp.ClientSession(headers={"User-Agent": "dep-rank-drift/1.0"}) as session:
+        result = await scrape_dependents(
+            session,
+            CANARY_URL,
+            min_stars=CANARY_MIN_STARS,
+            token=token,
+            max_pages=CANARY_MAX_PAGES,
+            rows=10,
+        )
+    if result.reason in _INCONCLUSIVE_REASONS:
+        # Transient network/rate failure *with* a token: we genuinely could not judge
+        # selector health this run. Don't page (exit 0 — a single flaky GitHub response
+        # shouldn't fail the job), but emit a GitHub `::warning::` annotation so the run
+        # is a visible non-success signal in the Actions summary rather than a silent green
+        # pass. A persistently inconclusive canary therefore shows as a wall of warnings.
+        sys.stderr.write(
+            f"::warning::INCONCLUSIVE on {CANARY_URL}: scrape ended on "
+            f"{result.reason.value}; selector health could not be checked this run.\n"
+        )
+        return 0
+    problems = evaluate_drift(len(result.repos), result.estimated_total_dependents, result.reason)
+    if problems:
+        sys.stderr.write(f"DRIFT DETECTED on {CANARY_URL}: " + "; ".join(problems) + "\n")
+        return 1
+    sys.stdout.write(
+        f"OK: {len(result.repos)} repos parsed, "
+        f"{result.estimated_total_dependents} total dependents reported "
+        f"(stop reason: {result.reason.value if result.reason else 'complete'}).\n"
+    )
+    return 0
+
+
+def main() -> None:
+    sys.exit(asyncio.run(_run()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -260,3 +260,128 @@ class TestVersionOption:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert __version__ in result.output
+
+
+class TestDepsHardeningFlags:
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_flags_pass_through_and_counts_use_matched(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        from dep_rank.core.models import ScrapeReason
+
+        mock_scrape.return_value = ScrapeResult(
+            repos=[Repository(owner="a", name="b", url="https://github.com/a/b", stars=900)],
+            pages_scraped=200,
+            max_pages=200,
+            estimated_total_pages=500,
+            estimated_total_dependents=15000,
+            complete=False,
+            reason=ScrapeReason.MAX_PAGES_REACHED,
+            matched_count=4200,
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "deps",
+                "https://github.com/django/django",
+                "--token",
+                "ghp_x",
+                "--concurrency",
+                "5",
+                "--no-adaptive-stop",
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == 0
+        _, kwargs = mock_scrape.call_args
+        assert kwargs["concurrency"] == 5
+        assert kwargs["adaptive_stop"] is False
+        assert kwargs["rows"] == 10  # default --rows
+        import json
+
+        payload = json.loads(result.stdout)
+        assert payload["complete"] is False
+        assert payload["reason"] == "max_pages_reached"
+        assert payload["total_count"] == 4200
+        assert "Scraped" not in result.stdout
+        assert "Found" not in result.stdout
+        assert "⚠" not in result.stdout
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_table_mode_shows_summary(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        mock_scrape.return_value = ScrapeResult(
+            repos=[Repository(owner="a", name="b", url="https://github.com/a/b", stars=900)],
+            pages_scraped=3,
+            max_pages=200,
+            estimated_total_pages=3,
+            estimated_total_dependents=90,
+            matched_count=1,
+        )
+        result = runner.invoke(
+            cli, ["deps", "https://github.com/django/django", "--token", "ghp_x"]
+        )
+        assert result.exit_code == 0
+        assert "Found" in result.output  # summary shown in table mode
+
+    @patch("dep_rank.cli.app.run_deps", new_callable=AsyncMock)
+    def test_unauthenticated_warning(
+        self, mock_run: AsyncMock, runner: CliRunner, mock_result: DependentsResult
+    ) -> None:
+        mock_run.return_value = mock_result
+        result = runner.invoke(cli, ["deps", "https://github.com/django/django"])
+        assert result.exit_code == 0
+        assert "token" in result.stderr.lower()
+        assert "60" in result.stderr  # mentions the 60/hour limit
+
+    @patch("dep_rank.cli.app.run_deps", new_callable=AsyncMock)
+    def test_no_warning_with_token(
+        self, mock_run: AsyncMock, runner: CliRunner, mock_result: DependentsResult
+    ) -> None:
+        mock_run.return_value = mock_result
+        result = runner.invoke(
+            cli, ["deps", "https://github.com/django/django", "--token", "ghp_x"]
+        )
+        assert result.exit_code == 0
+        assert "token" not in result.stderr.lower()
+
+    def test_concurrency_out_of_range_is_rejected(self, runner: CliRunner) -> None:
+        for bad in ("0", "11"):
+            result = runner.invoke(
+                cli,
+                ["deps", "https://github.com/x/y", "--token", "ghp_x", "--concurrency", bad],
+            )
+            assert result.exit_code != 0  # Click IntRange usage error
+            assert "concurrency" in result.output.lower() or "range" in result.output.lower()
+
+    @patch("dep_rank.cli.app.run_deps", new_callable=AsyncMock)
+    def test_max_pages_above_ceiling_warns_and_clamps(
+        self, mock_run: AsyncMock, runner: CliRunner, mock_result: DependentsResult
+    ) -> None:
+        mock_run.return_value = mock_result
+        result = runner.invoke(
+            cli,
+            ["deps", "https://github.com/x/y", "--token", "ghp_x", "--max-pages", "5000"],
+        )
+        assert result.exit_code == 0
+        assert "1000" in result.stderr  # warned about the cap
+        _, kwargs = mock_run.call_args
+        assert kwargs["max_pages"] == 1000

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -385,3 +385,141 @@ class TestDepsHardeningFlags:
         assert "1000" in result.stderr  # warned about the cap
         _, kwargs = mock_run.call_args
         assert kwargs["max_pages"] == 1000
+
+
+class TestSearchHardening:
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.search.search_code", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_search_uses_bounded_non_adaptive_topk(
+        self,
+        mock_scrape: AsyncMock,
+        mock_search: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        from dep_rank.core.models import CodeSearchResult
+
+        mock_scrape.return_value = ScrapeResult(
+            repos=[Repository(owner="a", name="b", url="https://github.com/a/b", stars=900)],
+            pages_scraped=3,
+            max_pages=200,
+            estimated_total_pages=3,
+            estimated_total_dependents=90,
+            matched_count=1,
+        )
+        mock_search.return_value = CodeSearchResult(
+            source="https://github.com/django/django", query="import os", hits=[], searched_repos=1
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "https://github.com/django/django",
+                "import os",
+                "--token",
+                "ghp_x",
+                "--max-repos",
+                "7",
+            ],
+        )
+        assert result.exit_code == 0
+        _, kwargs = mock_scrape.call_args
+        assert kwargs["rows"] == 7  # bounded to --max-repos
+        assert kwargs["adaptive_stop"] is False  # never heuristic on the search path
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.search.search_code", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_search_max_pages_above_ceiling_warns_and_clamps(
+        self,
+        mock_scrape: AsyncMock,
+        mock_search: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        """`search` mirrors `deps`: --max-pages above the ceiling warns and clamps."""
+        from dep_rank.core.models import CodeSearchResult
+
+        mock_scrape.return_value = ScrapeResult(
+            repos=[],
+            pages_scraped=1,
+            max_pages=1000,
+            estimated_total_pages=1,
+            estimated_total_dependents=0,
+            matched_count=0,
+        )
+        mock_search.return_value = CodeSearchResult(
+            source="https://github.com/django/django", query="import os", hits=[], searched_repos=0
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "https://github.com/django/django",
+                "import os",
+                "--token",
+                "ghp_x",
+                "--max-pages",
+                "5000",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "1000" in result.stderr  # warned about the cap (mirrors deps)
+        _, kwargs = mock_scrape.call_args
+        assert kwargs["max_pages"] == 1000  # clamped before the scrape
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.search.search_code", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_search_summary_reports_matched_count_not_len_repos(
+        self,
+        mock_scrape: AsyncMock,
+        mock_search: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        """Once `search` bounds `repos` to top-K (`rows=max_repos`), the scrape
+        summary must report `matched_count`, not `len(repos)`."""
+        from dep_rank.core.models import CodeSearchResult
+
+        mock_scrape.return_value = ScrapeResult(
+            repos=[
+                Repository(owner="a", name="b", url="https://github.com/a/b", stars=900),
+                Repository(owner="c", name="d", url="https://github.com/c/d", stars=800),
+            ],
+            pages_scraped=200,
+            max_pages=200,
+            estimated_total_pages=200,
+            estimated_total_dependents=15000,
+            matched_count=4200,
+        )
+        mock_search.return_value = CodeSearchResult(
+            source="https://github.com/django/django", query="import os", hits=[], searched_repos=2
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "search",
+                "https://github.com/django/django",
+                "import os",
+                "--token",
+                "ghp_x",
+                "--max-repos",
+                "2",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "4,200" in result.output  # matched_count, not len(repos)==2

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -168,3 +168,32 @@ class TestFormatScrapeSummary:
         )
         assert "0/1000 pages (0.0%)" in summary
         assert "Found 0 dependents" in summary
+
+
+class TestPartialWarning:
+    def test_reasons_have_distinct_messages(self) -> None:
+        from dep_rank.cli.formatters import partial_warning
+        from dep_rank.core.models import ScrapeReason
+
+        msgs = {
+            partial_warning(r)
+            for r in (
+                ScrapeReason.MAX_PAGES_REACHED,
+                ScrapeReason.TREND_CONVERGED,
+                ScrapeReason.NETWORK_FAILURE,
+                ScrapeReason.RATE_LIMITED,
+            )
+        }
+        assert len(msgs) == 4  # each reason renders a distinct line
+
+    def test_max_pages_mentions_flag(self) -> None:
+        from dep_rank.cli.formatters import partial_warning
+        from dep_rank.core.models import ScrapeReason
+
+        assert "--max-pages" in partial_warning(ScrapeReason.MAX_PAGES_REACHED)
+
+    def test_converged_mentions_opt_out(self) -> None:
+        from dep_rank.cli.formatters import partial_warning
+        from dep_rank.core.models import ScrapeReason
+
+        assert "--no-adaptive-stop" in partial_warning(ScrapeReason.TREND_CONVERGED)

--- a/tests/core/test_drift_check.py
+++ b/tests/core/test_drift_check.py
@@ -13,39 +13,38 @@ import pytest
 
 import dep_rank.scripts.drift_check as drift_check
 from dep_rank.core.models import Repository, ScrapeReason, ScrapeResult
-from dep_rank.scripts.drift_check import evaluate_drift
 
 
 def test_healthy_result_has_no_problems() -> None:
-    assert evaluate_drift(repos_count=5, total_dependents=15000) == []
+    assert drift_check.evaluate_drift(repos_count=5, total_dependents=15000) == []
 
 
 def test_zero_repos_flags_item_selectors() -> None:
-    problems = evaluate_drift(repos_count=0, total_dependents=15000)
+    problems = drift_check.evaluate_drift(repos_count=0, total_dependents=15000)
     assert any("selector" in p.lower() for p in problems)
 
 
 def test_zero_total_flags_header() -> None:
-    problems = evaluate_drift(repos_count=5, total_dependents=0)
+    problems = drift_check.evaluate_drift(repos_count=5, total_dependents=0)
     assert any("header" in p.lower() or "count" in p.lower() for p in problems)
 
 
 def test_both_broken_flags_both() -> None:
-    assert len(evaluate_drift(repos_count=0, total_dependents=0)) == 2
+    assert len(drift_check.evaluate_drift(repos_count=0, total_dependents=0)) == 2
 
 
 @pytest.mark.parametrize("reason", [ScrapeReason.NETWORK_FAILURE, ScrapeReason.RATE_LIMITED])
 def test_transport_failure_is_inconclusive_not_drift(reason: ScrapeReason) -> None:
     """A network/rate failure must not be reported as selector drift, even when the
     failed scrape returned zero repos and a zero header count."""
-    assert evaluate_drift(repos_count=0, total_dependents=0, reason=reason) == []
+    assert drift_check.evaluate_drift(repos_count=0, total_dependents=0, reason=reason) == []
 
 
 def test_max_pages_reached_still_evaluates_selectors() -> None:
     """MAX_PAGES_REACHED is expected on the multi-page canary; it does not suppress
     evaluation — healthy counts pass, and a zero-repo page still flags drift."""
-    assert evaluate_drift(5, 15000, ScrapeReason.MAX_PAGES_REACHED) == []
-    assert evaluate_drift(0, 15000, ScrapeReason.MAX_PAGES_REACHED) != []
+    assert drift_check.evaluate_drift(5, 15000, ScrapeReason.MAX_PAGES_REACHED) == []
+    assert drift_check.evaluate_drift(0, 15000, ScrapeReason.MAX_PAGES_REACHED) != []
 
 
 def test_missing_token_fails_before_scraping(

--- a/tests/core/test_drift_check.py
+++ b/tests/core/test_drift_check.py
@@ -1,0 +1,145 @@
+"""Tests for the drift-check evaluation logic and the _run guards (no network I/O).
+
+The _run tests monkeypatch ``scrape_dependents`` so a ``ClientSession`` is created but
+never issues a request — the token guard short-circuits before scraping, and the
+inconclusive case returns a stubbed result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import dep_rank.scripts.drift_check as drift_check
+from dep_rank.core.models import Repository, ScrapeReason, ScrapeResult
+from dep_rank.scripts.drift_check import evaluate_drift
+
+
+def test_healthy_result_has_no_problems() -> None:
+    assert evaluate_drift(repos_count=5, total_dependents=15000) == []
+
+
+def test_zero_repos_flags_item_selectors() -> None:
+    problems = evaluate_drift(repos_count=0, total_dependents=15000)
+    assert any("selector" in p.lower() for p in problems)
+
+
+def test_zero_total_flags_header() -> None:
+    problems = evaluate_drift(repos_count=5, total_dependents=0)
+    assert any("header" in p.lower() or "count" in p.lower() for p in problems)
+
+
+def test_both_broken_flags_both() -> None:
+    assert len(evaluate_drift(repos_count=0, total_dependents=0)) == 2
+
+
+@pytest.mark.parametrize("reason", [ScrapeReason.NETWORK_FAILURE, ScrapeReason.RATE_LIMITED])
+def test_transport_failure_is_inconclusive_not_drift(reason: ScrapeReason) -> None:
+    """A network/rate failure must not be reported as selector drift, even when the
+    failed scrape returned zero repos and a zero header count."""
+    assert evaluate_drift(repos_count=0, total_dependents=0, reason=reason) == []
+
+
+def test_max_pages_reached_still_evaluates_selectors() -> None:
+    """MAX_PAGES_REACHED is expected on the multi-page canary; it does not suppress
+    evaluation — healthy counts pass, and a zero-repo page still flags drift."""
+    assert evaluate_drift(5, 15000, ScrapeReason.MAX_PAGES_REACHED) == []
+    assert evaluate_drift(0, 15000, ScrapeReason.MAX_PAGES_REACHED) != []
+
+
+def test_missing_token_fails_before_scraping(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A missing DRIFT_CHECK_TOKEN exits 2 and never scrapes — no silent unauth run that
+    could pass-while-blind. Guards against the 'green check that never checks' failure."""
+    monkeypatch.delenv("DRIFT_CHECK_TOKEN", raising=False)
+
+    async def _must_not_scrape(*args: object, **kwargs: object) -> ScrapeResult:
+        raise AssertionError("scrape_dependents must not run without a token")
+
+    monkeypatch.setattr(drift_check, "scrape_dependents", _must_not_scrape)
+    assert asyncio.run(drift_check._run()) == 2
+    assert "DRIFT_CHECK_TOKEN" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("reason", [ScrapeReason.NETWORK_FAILURE, ScrapeReason.RATE_LIMITED])
+def test_inconclusive_with_token_warns_but_exits_zero(
+    reason: ScrapeReason,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A transport failure *with* a token is inconclusive: exit 0 (don't page on a flaky
+    GitHub response) but emit a visible ``::warning::`` annotation, not a silent pass."""
+    monkeypatch.setenv("DRIFT_CHECK_TOKEN", "ghp_x")
+    stub = ScrapeResult(
+        repos=[],
+        pages_scraped=0,
+        max_pages=2,
+        estimated_total_pages=0,
+        estimated_total_dependents=0,
+        complete=False,
+        reason=reason,
+        matched_count=0,
+    )
+
+    async def _fake_scrape(*args: object, **kwargs: object) -> ScrapeResult:
+        return stub
+
+    monkeypatch.setattr(drift_check, "scrape_dependents", _fake_scrape)
+    assert asyncio.run(drift_check._run()) == 0
+    err = capsys.readouterr().err
+    assert "::warning::" in err
+    assert "INCONCLUSIVE" in err
+
+
+def test_drift_detected_with_token_exits_one(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A reachable scrape (non-transport reason) that parses zero repos AND a zero header
+    count is real drift: exit 1 with a 'DRIFT DETECTED' message on stderr. This is the
+    path that fails the weekly CI job — the canary's whole reason to exist."""
+    monkeypatch.setenv("DRIFT_CHECK_TOKEN", "ghp_x")
+    stub = ScrapeResult(
+        repos=[],
+        pages_scraped=2,
+        max_pages=2,
+        estimated_total_pages=2,
+        estimated_total_dependents=0,
+        complete=False,
+        reason=ScrapeReason.MAX_PAGES_REACHED,
+        matched_count=0,
+    )
+
+    async def _fake_scrape(*args: object, **kwargs: object) -> ScrapeResult:
+        return stub
+
+    monkeypatch.setattr(drift_check, "scrape_dependents", _fake_scrape)
+    assert asyncio.run(drift_check._run()) == 1
+    assert "DRIFT DETECTED" in capsys.readouterr().err
+
+
+def test_healthy_scrape_with_token_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A reachable, complete scrape with parsed repos and a non-zero header count is
+    healthy: exit 0 with an 'OK:' summary on stdout. Uses reason=None to also exercise
+    the ``'complete'`` branch of the summary's reason ternary."""
+    monkeypatch.setenv("DRIFT_CHECK_TOKEN", "ghp_x")
+    stub = ScrapeResult(
+        repos=[Repository(owner="a", name="b", url="https://github.com/a/b", stars=900)],
+        pages_scraped=2,
+        max_pages=2,
+        estimated_total_pages=2,
+        estimated_total_dependents=15000,
+        complete=True,
+        reason=None,
+        matched_count=1,
+    )
+
+    async def _fake_scrape(*args: object, **kwargs: object) -> ScrapeResult:
+        return stub
+
+    monkeypatch.setattr(drift_check, "scrape_dependents", _fake_scrape)
+    assert asyncio.run(drift_check._run()) == 0
+    assert "OK:" in capsys.readouterr().out

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -218,6 +218,87 @@ class TestScrapeResultContractFields:
         assert result.reason == reason
 
 
+class TestDependentsResultContractFields:
+    def test_defaults(self) -> None:
+        from datetime import UTC, datetime
+
+        result = DependentsResult(
+            source="https://github.com/x/y",
+            total_count=10,
+            filtered_count=10,
+            repos=[],
+            dependent_type=DependentType.REPOSITORY,
+            scraped_at=datetime.now(tz=UTC),
+        )
+        assert result.complete is True
+        assert result.reason is None
+        assert result.pages_scraped == 0
+        assert result.estimated_total_pages == 0
+
+
+class TestDependentsResultInvariant:
+    def test_complete_must_equal_reason_absence(self) -> None:
+        from datetime import datetime
+
+        import pytest
+        from pydantic import ValidationError
+
+        from dep_rank.core.models import DependentType, ScrapeReason
+
+        base_dt = datetime(2026, 1, 1)  # noqa: DTZ001
+        with pytest.raises(ValidationError):
+            DependentsResult(
+                source="https://github.com/x/y",
+                total_count=0,
+                filtered_count=0,
+                repos=[],
+                dependent_type=DependentType.REPOSITORY,
+                scraped_at=base_dt,
+                complete=False,
+                reason=None,
+            )
+        with pytest.raises(ValidationError):
+            DependentsResult(
+                source="https://github.com/x/y",
+                total_count=0,
+                filtered_count=0,
+                repos=[],
+                dependent_type=DependentType.REPOSITORY,
+                scraped_at=base_dt,
+                complete=True,
+                reason=ScrapeReason.NETWORK_FAILURE,
+            )
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            ScrapeReason.MAX_PAGES_REACHED,
+            ScrapeReason.TREND_CONVERGED,
+            ScrapeReason.NETWORK_FAILURE,
+            ScrapeReason.RATE_LIMITED,
+        ],
+    )
+    def test_every_reason_marks_incomplete(self, reason: ScrapeReason) -> None:
+        """All four terminal reasons construct cleanly on the user-facing model and
+        satisfy the invariant."""
+        from datetime import datetime
+
+        from dep_rank.core.models import DependentType
+
+        result = DependentsResult(
+            source="https://github.com/x/y",
+            total_count=0,
+            filtered_count=0,
+            repos=[],
+            dependent_type=DependentType.REPOSITORY,
+            scraped_at=datetime(2026, 1, 1),  # noqa: DTZ001
+            complete=False,
+            reason=reason,
+        )
+        assert result.complete is False
+        assert result.reason == reason
+
+
 class TestScrapeSnapshot:
     def test_per_page_snapshot_defaults(self) -> None:
         from dep_rank.core.models import ScrapeSnapshot


### PR DESCRIPTION
## Summary

Phase 4 of the scraper-hardening effort (#74): surfaces the hardened scraper through the CLI, documents the new contract, and adds a weekly drift-check canary. Builds on Phases 1–3 (terminal contract, streaming top-K, stale-while-revalidate cache) — all already merged.

- **`deps` flags & honest output:** adds `--concurrency` (Click `IntRange(1, 10)`, default 3) and `--adaptive-stop/--no-adaptive-stop` (default on); `--max-pages` default drops **1000 → 200** (ceiling 1000, with a warn-and-clamp above it). `total_count`/`filtered_count` now come from `ScrapeResult.matched_count` (an honest lower bound across scraped pages) instead of `len(repos)`. `complete`/`reason` are carried into `DependentsResult` and its JSON. `--format json` is now **silent on stdout** (no human summary/banner/⚠ leaks in — verified by asserting on `result.stdout`). An **unauthenticated-token warning** prints to **stderr** (so JSON stdout stays pure).
- **`search` bounded non-adaptive top-K:** passes `rows=max_repos` with `adaptive_stop=False` (never heuristic on the search path); gains `--concurrency`/`--max-pages` (same warn-and-clamp), reports `matched_count` in its summary, and prints a partial-result notice. It intentionally does **not** expose `--no-adaptive-stop` (documented asymmetry).
- **`partial_warning` formatter:** one-line caveat per `ScrapeReason`, shared by both commands.
- **`DependentsResult` contract fields:** `complete`/`reason`/`pages_scraped`/`estimated_total_pages` (deferred from Phase 1), guarded by the same `complete == (reason is None)` invariant `ScrapeResult` carries.
- **Drift canary** (`src/dep_rank/scripts/drift_check.py` + `.github/workflows/scraper-drift-check.yml`): weekly + `workflow_dispatch`. Verifies GitHub's dependents selectors still parse a known repo. Fails **visibly** by design — missing `DRIFT_CHECK_TOKEN` → exit 2; transport failure (network/rate) → exit 0 + a `::warning::` annotation (inconclusive, never a silent green pass); real selector/header drift → exit 1.
- **README:** token recommendation, ~60 req/hr unauthenticated limit, the new flags (both commands), the partial-result contract, and a stale-while-revalidate caching note.

## Scope

Per the plan, the §6 **Live refining top-K table** is deferred to **Phase 5** (additive `on_partial` callback) — not in this PR. Phase 4 keeps the existing per-page progress bar. The core scraper (`scraper.py`) is unchanged by this PR (diff is empty) — Phases 1/2/3 internals are untouched, and both commands still call `scrape_dependents` (not `stream_dependents` directly), preserving the SWR drain-in-`finally` lifecycle.

## ⚠️ Maintainer action required

The drift workflow needs a **`DRIFT_CHECK_TOKEN`** repo secret (fine-grained read-only PAT). **The job hard-fails (exit 2) until the secret exists** — this is intentional: an unauthenticated canary risks being 429'd into a permanent "inconclusive → exit 0" pass that never actually checks selectors, so a red job is the correct prompt to configure the token.

## Behavior changes to call out

- `--max-pages` default **1000 → 200** (ceiling 1000; above it warns + clamps).
- Unauthenticated scraping now ~60 requests/hour; `deps` warns to stderr when no token is configured.
- `total_count`/`filtered_count` now reflect matched dependents across scraped pages (a **lower bound** when `complete=false`), not `len(repos)`.

## Test Plan

- [x] `uv run pytest` — **201 passed, 94.17% coverage** (90% gate).
- [x] `uv run ruff check src tests` + `ruff format --check` — clean; `mypy --strict` (pre-commit) clean.
- [x] `uv run dep-rank deps --help` shows `--concurrency`, `--adaptive-stop/--no-adaptive-stop`, `--max-pages` (default 200); `uv run dep-rank search --help` shows `--concurrency`, `--max-pages` (default 200) and **no** `--no-adaptive-stop`.
- [x] New coverage: `partial_warning` per-reason messages; `deps` flag pass-through + matched-count + JSON-silent stdout + stderr unauth warning + `IntRange` rejection + max-pages clamp; `search` bounded non-adaptive top-K + clamp + matched-count summary; `DependentsResult` invariant; drift `evaluate_drift` (healthy/zero-repos/zero-header/both/inconclusive/max-pages) + `_run` exit-code paths (missing-token=2, inconclusive=0+`::warning::`, drift=1, healthy=0).
- [x] No fabricated Action SHA — `actions/checkout` ref copied byte-for-byte from `ci.yml`; drift workflow YAML validated; `permissions: contents: read` (least privilege).

Spec: `docs/superpowers/specs/2026-05-30-scraper-hardening-design.md` §1 (`search` rows), §2 (counts/contract), §6 (CLI surface minus Live top-K), §7 (drift), §8 (defaults).

Refs #74.
