### PR TITLE
feat: scraper hardening phase 5 — live refining top-K table (closes #74)

### DIFF
--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -38,11 +38,12 @@ async def run_deps(
     """Run the deps pipeline: scrape → enrich → return."""
     import aiohttp
     from rich.console import Console
-    from rich.progress import BarColumn, Progress, TextColumn, TimeElapsedColumn
+    from rich.live import Live
 
-    from dep_rank.cli.formatters import format_scrape_summary
+    from dep_rank.cli.formatters import build_topk_table, format_scrape_summary
     from dep_rank.core.cache import SqliteCache
     from dep_rank.core.graphql import enrich_with_graphql
+    from dep_rank.core.models import ScrapeSnapshot
     from dep_rank.core.scraper import scrape_dependents
 
     console = Console(stderr=True)
@@ -56,33 +57,20 @@ async def run_deps(
         async with aiohttp.ClientSession(
             headers={"User-Agent": "dep-rank/0.1"},
         ) as session:
-            progress_ctx = None
-            task_id = None
-            if not verbose and not quiet:
-                progress_ctx = Progress(
-                    TextColumn("[bold green]Scraping dependents..."),
-                    BarColumn(),
-                    TextColumn("{task.completed}/{task.total} pages ({task.percentage:>5.1f}%)"),
-                    TextColumn("·"),
-                    TextColumn("{task.fields[est_text]}"),
-                    TimeElapsedColumn(),
-                    console=console,
-                )
-                task_id = progress_ctx.add_task(
-                    "scraping", total=max_pages, est_text="estimating..."
-                )
+            show_live = not verbose and not quiet
+            live = (
+                Live(console=console, refresh_per_second=4, transient=True) if show_live else None
+            )
 
-            async def on_progress(page: int, est_total: int) -> None:
-                if progress_ctx is not None and task_id is not None:
-                    est_text = (
-                        f"{page}/~{est_total:,} estimated pages ({page / est_total * 100:.2f}%)"
-                        if est_total > 0
-                        else "estimating..."
-                    )
-                    progress_ctx.update(task_id, completed=page, est_text=est_text)
+            async def on_partial(snapshot: ScrapeSnapshot) -> None:
+                # Update on EVERY snapshot, even when top_k is empty: high --min-stars,
+                # rows=0, or a no-match scrape must still show live progress.
+                # build_topk_table renders page/matched/empty-state for the empty case.
+                if live is not None:
+                    live.update(build_topk_table(snapshot))
 
-            if progress_ctx is not None:
-                progress_ctx.start()
+            if live is not None:
+                live.start()
             try:
                 scrape_result = await scrape_dependents(
                     session,
@@ -90,16 +78,16 @@ async def run_deps(
                     dependent_type=dep_type,
                     min_stars=min_stars,
                     cache=cache,
-                    on_progress=on_progress,
                     token=token,
                     max_pages=max_pages,
                     rows=rows,
                     concurrency=concurrency,
                     adaptive_stop=adaptive_stop,
+                    on_partial=on_partial,
                 )
             finally:
-                if progress_ctx is not None:
-                    progress_ctx.stop()
+                if live is not None:
+                    live.stop()
 
             repos = scrape_result.repos
             total_count = scrape_result.matched_count

--- a/src/dep_rank/cli/formatters.py
+++ b/src/dep_rank/cli/formatters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from rich.console import Console
 from rich.table import Table
 
-from dep_rank.core.models import CodeSearchResult, DependentsResult, ScrapeReason
+from dep_rank.core.models import CodeSearchResult, DependentsResult, ScrapeReason, ScrapeSnapshot
 
 console = Console()
 
@@ -91,6 +91,30 @@ def partial_warning(reason: ScrapeReason | None) -> str:
     }
     text = messages.get(reason, "Results are partial.") if reason else "Results are partial."
     return f"[yellow]⚠ {text}[/yellow]"
+
+
+def build_topk_table(snapshot: ScrapeSnapshot) -> Table:
+    """Render the running top-K as a Rich table for the Live display during a scrape.
+
+    The title always carries progress context (page + matched count) so that an empty
+    top-K — high ``--min-stars``, ``rows=0``, or a genuinely no-match scrape — still
+    renders live progress instead of a blank frame. An empty top-K shows a placeholder
+    row rather than an empty table.
+    """
+    table = Table(
+        title=(
+            f"Top dependents so far "
+            f"(page {snapshot.pages_scraped}, {snapshot.matched_count} matched)"
+        )
+    )
+    table.add_column("Repository", style="cyan", no_wrap=True)
+    table.add_column("Stars", justify="right", style="yellow")
+    if snapshot.top_k:
+        for repo in snapshot.top_k:
+            table.add_row(f"{repo.owner}/{repo.name}", humanize(repo.stars))
+    else:
+        table.add_row("(no matching repositories yet)", "—")
+    return table
 
 
 def format_scrape_summary(

--- a/src/dep_rank/core/scraper.py
+++ b/src/dep_rank/core/scraper.py
@@ -574,6 +574,7 @@ async def scrape_dependents(
     concurrency: int = DEFAULT_CONCURRENCY,
     adaptive_stop: bool = True,
     rate_limiter: AdaptiveRateLimiter | None = None,
+    on_partial: Callable[[ScrapeSnapshot], Awaitable[None]] | None = None,
 ) -> ScrapeResult:
     """Compatibility wrapper: drain stream_dependents into a ScrapeResult.
 
@@ -600,6 +601,8 @@ async def scrape_dependents(
         adaptive_stop=adaptive_stop,
         rate_limiter=rate_limiter,
     ):
+        if on_partial is not None:
+            await on_partial(snapshot)
         terminal = snapshot
 
     assert terminal is not None  # noqa: S101  # stream always yields a terminal snapshot

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -523,3 +523,44 @@ class TestSearchHardening:
         )
         assert result.exit_code == 0
         assert "4,200" in result.output  # matched_count, not len(repos)==2
+
+
+class TestDepsLiveTopK:
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.get", new_callable=AsyncMock, return_value=None)
+    @patch("dep_rank.core.cache.SqliteCache.put", new_callable=AsyncMock)
+    @patch("rich.live.Live.update")
+    def test_live_path_drives_and_renders(
+        self,
+        mock_live_update: MagicMock,
+        mock_put: AsyncMock,
+        mock_get: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        from aioresponses import aioresponses
+
+        from tests.conftest import DEPENDENTS_HTML_LAST_PAGE, DEPENDENTS_HTML_PAGE_1
+
+        first = "https://github.com/owner/repo/network/dependents?dependent_type=REPOSITORY"
+        page2 = "https://github.com/owner/repo/network/dependents?page=2"
+        with aioresponses() as m:
+            # Two pages so the top-K refines across more than one snapshot: page 1 has
+            # alpha/beta/gamma and a Next link; page 2 adds delta/app and ends the walk.
+            m.get(first, body=DEPENDENTS_HTML_PAGE_1)
+            m.get(page2, body=DEPENDENTS_HTML_LAST_PAGE)
+            result = runner.invoke(
+                cli,
+                ["deps", "https://github.com/owner/repo", "--token", "ghp_x", "--min-stars", "5"],
+            )
+        assert result.exit_code == 0
+        # Repos from BOTH pages appear in the final (post-Live) summary table -> the walk
+        # consumed both pages.
+        assert "alpha/framework" in result.output
+        assert "delta/app" in result.output
+        # Live.update fired at least once per page snapshot (>=2).
+        assert mock_live_update.call_count >= 2

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -197,3 +197,52 @@ class TestPartialWarning:
         from dep_rank.core.models import ScrapeReason
 
         assert "--no-adaptive-stop" in partial_warning(ScrapeReason.TREND_CONVERGED)
+
+
+class TestBuildTopKTable:
+    def test_lists_repos_with_humanized_stars(self) -> None:
+        from rich.console import Console
+
+        from dep_rank.cli.formatters import build_topk_table
+        from dep_rank.core.models import Repository, ScrapeSnapshot
+
+        snap = ScrapeSnapshot(
+            top_k=[
+                Repository(owner="a", name="b", url="https://github.com/a/b", stars=1500),
+            ],
+            pages_scraped=2,
+            estimated_total_pages=5,
+            estimated_total_dependents=100,
+            matched_count=10,
+        )
+        table = build_topk_table(snap)
+        console = Console()
+        with console.capture() as cap:
+            console.print(table)
+        out = cap.get()
+        assert "a/b" in out
+        assert "1.5K" in out
+        assert "10 matched" in out  # progress context in the title
+        assert "page 2" in out  # progress context: page number in the title
+
+    def test_empty_top_k_still_renders_progress(self) -> None:
+        """A snapshot with no top-K (e.g. high --min-stars early on) must still render
+        progress context and a placeholder row, never a blank frame."""
+        from rich.console import Console
+
+        from dep_rank.cli.formatters import build_topk_table
+        from dep_rank.core.models import ScrapeSnapshot
+
+        snap = ScrapeSnapshot(
+            top_k=[],
+            pages_scraped=3,
+            estimated_total_pages=5,
+            estimated_total_dependents=100,
+            matched_count=0,
+        )
+        console = Console()
+        with console.capture() as cap:
+            console.print(build_topk_table(snap))
+        out = cap.get()
+        assert "page 3" in out
+        assert "no matching repositories" in out.lower()

--- a/tests/core/test_scraper_streaming.py
+++ b/tests/core/test_scraper_streaming.py
@@ -171,3 +171,25 @@ async def test_stream_emits_per_page_then_terminal() -> None:
     assert [s.done for s in snaps] == [False, False, True]
     assert snaps[-1].complete is True
     assert snaps[-1].reason is None
+
+
+@pytest.mark.asyncio
+async def test_on_partial_called_per_snapshot() -> None:
+    from dep_rank.core.models import ScrapeSnapshot
+
+    seen: list[ScrapeSnapshot] = []
+
+    async def on_partial(snap: ScrapeSnapshot) -> None:
+        seen.append(snap)
+
+    p1 = _page(_item("a", "one", 100) + _item("b", "two", 80), next_page=None)
+    with aioresponses() as m:
+        m.get(FIRST, body=p1)
+        async with ClientSession() as session:
+            await scrape_dependents(
+                session, BASE, rows=5, on_partial=on_partial, adaptive_stop=False
+            )
+    # one per-page snapshot (done=False) + one terminal snapshot (done=True)
+    assert len(seen) == 2
+    assert seen[0].done is False
+    assert seen[-1].done is True


### PR DESCRIPTION
## Summary

Phase 5 — the final phase — of the scraper-hardening effort (#74): implements spec §6's **live refining top-K table** in the `deps` table view, and closes the issue. Builds on Phases 1–4 (terminal contract, streaming top-K, stale-while-revalidate cache, CLI flags + drift CI) — all already merged.

- **`on_partial` snapshot callback (`scrape_dependents`):** an *additive* keyword-only `on_partial: Callable[[ScrapeSnapshot], Awaitable[None]]` hook on the wrapper, invoked per snapshot as the internal `stream_dependents` generator is drained. The snapshot-channel analogue of the existing scalar `on_progress`.
- **`build_topk_table(snapshot)` formatter:** renders the running top-K as a Rich `Table`. The title always carries progress context (`page N, M matched`) and an empty top-K shows a placeholder row, so the Live frame is **never blank** — even with high `--min-stars`, `rows=0`, or a genuine no-match scrape.
- **Live top-K in `run_deps`:** replaces the per-page `Progress` bar with a `rich.live.Live` table fed by `on_partial`. The table refines as pages stream in. Because the CLI still calls `scrape_dependents` (not `stream_dependents` directly), every existing test mock stays valid — a mock simply never invokes `on_partial`.

## Architecture (per the plan)

This does **not** reverse spec decision D1 ("generator is primary"). `stream_dependents` remains the primary streaming primitive (built in Phase 2); `scrape_dependents` is still a thin wrapper that drains it. `on_partial` is layered *on the wrapper* — forwarding the generator's snapshots — purely so the CLI gains a live view without churning the existing `scrape_dependents`-based test mocks. Any consumer wanting the spec's preferred shape can still `async for` over `stream_dependents` directly.

## Cross-phase safety

- The core `scraper.py` diff is **+3/−0**: the `on_partial` param plus two drain-loop lines. No change to `stream_dependents`, the stale-while-revalidate cache lifecycle, the drain-in-`finally`, adaptive-stop, or rate limiting.
- The wrapper's `max_pages` default stays `MAX_PAGES_CEILING` (1000); the bounded 200-page default and the warn-and-clamp live on the CLI (unchanged from Phase 4).
- `search`'s `_run` intentionally keeps its own per-page `Progress` bar — Phase 5 is scoped to `deps` only.
- Tests are net-additive (`tests/` diff +113/−1, where the one "deletion" is adding `MagicMock` to an import). No existing test deleted, weakened, or skipped.

## JSON stays silent (spec §6)

`--format json` sets `quiet=True` → `show_live = not verbose and not quiet` is `False` → no `Live` is created and `live.update` is never called; the human summary and partial banner remain gated behind `if not quiet:`. A JSON-format test parses `result.stdout` as JSON, so any table/summary/Live leak would fail the suite.

## Test Plan

- [x] `uv run pytest` — **205 passed, 94.58% coverage** (90% gate).
- [x] `uv run ruff check src tests` + `ruff format --check` — clean; `mypy --strict` (pre-commit) clean. No stale `Progress`/`on_progress` imports remain in `run_deps`.
- [x] New coverage: `on_partial` fires per snapshot with correct `done` flags (`test_on_partial_called_per_snapshot`); `build_topk_table` humanized stars + progress-in-title + empty-state placeholder (`TestBuildTopKTable`); live-path smoke test driving a real two-page scrape over `aioresponses` and asserting `Live.update` fired per snapshot (`call_count >= 2`, which fails if `on_partial` is dropped) plus both pages' repos in the final output (`TestDepsLiveTopK`).
- [x] **#74 acceptance:** all four `ScrapeReason` terminal reasons exercised on **both** result models — `TestScrapeResultContractFields::test_every_reason_marks_incomplete` (Phase 1) and `TestDependentsResultInvariant::test_every_reason_marks_incomplete` (Phase 4), all 8 parametrizations green.
- [x] `uv run dep-rank deps --help` — flags unchanged (`--max-pages` default 200/ceiling 1000, `--concurrency` 1–10 default 3, `--adaptive-stop/--no-adaptive-stop` default on).

Spec: `docs/superpowers/specs/2026-05-30-scraper-hardening-design.md` §6 (Live top-K; JSON stays silent). This PR completes the approved spec contract across Phases 1–5; no scope deviations remain.

Fixes #74.
