### PR TITLE
TEST: issue #93 staging — DO NOT MERGE (throwaway)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
           if git diff --quiet uv.lock; then
             echo "No lockfile changes"
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          CONTENT=$(base64 -w0 uv.lock)
+          base64 -w0 uv.lock > "$RUNNER_TEMP/uv.lock.b64"
           HEAD_OID=$(git rev-parse HEAD)
           # shellcheck disable=SC2016
           gh api graphql -f query='
@@ -61,7 +62,7 @@ jobs:
             -f "input[expectedHeadOid]=${HEAD_OID}" \
             -f "input[message][headline]=deps: update uv.lock" \
             -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -f "input[fileChanges][additions][0][contents]=${CONTENT}"
+            -F "input[fileChanges][additions][0][contents]=@$RUNNER_TEMP/uv.lock.b64"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   update-lockfile:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'j7an'
     runs-on: ubuntu-latest
     outputs:
       committed: ${{ steps.commit.outputs.committed }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -98,6 +103,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -123,6 +133,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "selectolax>=0.3,<1",
     "pydantic>=2.0,<3",
     "appdirs>=1.4,<2",
-    "click>=8.1,<9",
+    "click>=8.1,<8.4",
     "rich>=13.0,<15",
 ]
 


### PR DESCRIPTION
Throwaway validation PR for issue #93. **Do not merge — will be closed and branch deleted.**

Purpose: exercise the fixed `update-lockfile` repair path end-to-end.
- Actor gate temporarily widened to match `j7an` (test-only).
- `click` tightened to `<8.4` (locked 8.4.0 violates it) → forces a real `uv.lock` diff; lock left stale.

Expected: `update-lockfile` regenerates `uv.lock` and commits it via createCommitOnBranch (no 'Argument list too long'); the bot push triggers a fresh run; checks attach to the repaired head.

Refs #93