### PR TITLE
TEST: issue #93 staging (corrected payload) — DO NOT MERGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
           if git diff --quiet uv.lock; then
             echo "No lockfile changes"
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          CONTENT=$(base64 -w0 uv.lock)
+          base64 -w0 uv.lock > "$RUNNER_TEMP/uv.lock.b64"
           HEAD_OID=$(git rev-parse HEAD)
           # shellcheck disable=SC2016
           gh api graphql -f query='
@@ -61,7 +62,7 @@ jobs:
             -f "input[expectedHeadOid]=${HEAD_OID}" \
             -f "input[message][headline]=deps: update uv.lock" \
             -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -f "input[fileChanges][additions][0][contents]=${CONTENT}"
+            -F "input[fileChanges][additions][0][contents]=@$RUNNER_TEMP/uv.lock.b64"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   update-lockfile:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'j7an'
     runs-on: ubuntu-latest
     outputs:
       committed: ${{ steps.commit.outputs.committed }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,27 @@ jobs:
           base64 -w0 uv.lock > "$RUNNER_TEMP/uv.lock.b64"
           HEAD_OID=$(git rev-parse HEAD)
           # shellcheck disable=SC2016
-          gh api graphql -f query='
-            mutation($input: CreateCommitOnBranchInput!) {
-              createCommitOnBranch(input: $input) {
-                commit { url }
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg branch "$HEAD_REF" \
+            --arg oid "$HEAD_OID" \
+            --rawfile contents "$RUNNER_TEMP/uv.lock.b64" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  expectedHeadOid: $oid,
+                  message: { headline: "deps: update uv.lock" },
+                  fileChanges: { additions: [ { path: "uv.lock", contents: $contents } ] }
+                }
               }
-            }
-          ' -f "input[branchRef][repositoryNameWithOwner]=$REPOSITORY" \
-            -f "input[branchRef][branchName]=$HEAD_REF" \
-            -f "input[expectedHeadOid]=${HEAD_OID}" \
-            -f "input[message][headline]=deps: update uv.lock" \
-            -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -F "input[fileChanges][additions][0][contents]=@$RUNNER_TEMP/uv.lock.b64"
+            }' > "$RUNNER_TEMP/commit.json"
+          RESPONSE=$(gh api graphql --input "$RUNNER_TEMP/commit.json")
+          if [ -z "$(printf '%s' "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')" ]; then
+            echo "::error::createCommitOnBranch did not create a commit. Response: $RESPONSE"
+            exit 1
+          fi
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -98,6 +103,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -123,6 +133,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "selectolax>=0.3,<1",
     "pydantic>=2.0,<3",
     "appdirs>=1.4,<2",
-    "click>=8.1,<9",
+    "click>=8.1,<8.4",
     "rich>=13.0,<15",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -234,14 +234,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9,<4" },
     { name = "aiosqlite", specifier = ">=0.19,<1" },
     { name = "appdirs", specifier = ">=1.4,<2" },
-    { name = "click", specifier = ">=8.1,<9" },
+    { name = "click", specifier = ">=8.1,<8.4" },
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "rich", specifier = ">=13.0,<15" },
     { name = "selectolax", specifier = ">=0.3,<1" },


### PR DESCRIPTION
Throwaway re-test of the corrected `createCommitOnBranch` payload (jq + `--input`, additions as array, `branch` field). **Do not merge — will be closed and branch deleted.**

Forces a real `uv.lock` drift (click <8.4 vs locked 8.4.0); actor gate temporarily widened to `j7an` (test-only).

Expected: `update-lockfile` regenerates `uv.lock`, createCommitOnBranch pushes a REAL repair commit (response has commit.oid), the bot push triggers a fresh run, and checks attach to the repaired head.

Refs #93