### PR TITLE
fix(ci): repair uv.lock without argv limit + loud-fail guard (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
           REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
           if git diff --quiet uv.lock; then
             echo "No lockfile changes"
             echo "committed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          CONTENT=$(base64 -w0 uv.lock)
+          base64 -w0 uv.lock > "$RUNNER_TEMP/uv.lock.b64"
           HEAD_OID=$(git rev-parse HEAD)
           # shellcheck disable=SC2016
           gh api graphql -f query='
@@ -61,7 +62,7 @@ jobs:
             -f "input[expectedHeadOid]=${HEAD_OID}" \
             -f "input[message][headline]=deps: update uv.lock" \
             -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -f "input[fileChanges][additions][0][contents]=${CONTENT}"
+            -F "input[fileChanges][additions][0][contents]=@$RUNNER_TEMP/uv.lock.b64"
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,18 +51,27 @@ jobs:
           base64 -w0 uv.lock > "$RUNNER_TEMP/uv.lock.b64"
           HEAD_OID=$(git rev-parse HEAD)
           # shellcheck disable=SC2016
-          gh api graphql -f query='
-            mutation($input: CreateCommitOnBranchInput!) {
-              createCommitOnBranch(input: $input) {
-                commit { url }
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg branch "$HEAD_REF" \
+            --arg oid "$HEAD_OID" \
+            --rawfile contents "$RUNNER_TEMP/uv.lock.b64" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  expectedHeadOid: $oid,
+                  message: { headline: "deps: update uv.lock" },
+                  fileChanges: { additions: [ { path: "uv.lock", contents: $contents } ] }
+                }
               }
-            }
-          ' -f "input[branchRef][repositoryNameWithOwner]=$REPOSITORY" \
-            -f "input[branchRef][branchName]=$HEAD_REF" \
-            -f "input[expectedHeadOid]=${HEAD_OID}" \
-            -f "input[message][headline]=deps: update uv.lock" \
-            -f "input[fileChanges][additions][0][path]=uv.lock" \
-            -F "input[fileChanges][additions][0][contents]=@$RUNNER_TEMP/uv.lock.b64"
+            }' > "$RUNNER_TEMP/commit.json"
+          RESPONSE=$(gh api graphql --input "$RUNNER_TEMP/commit.json")
+          if [ -z "$(printf '%s' "$RESPONSE" | jq -r '.data.createCommitOnBranch.commit.oid // empty')" ]; then
+            echo "::error::createCommitOnBranch did not create a commit. Response: $RESPONSE"
+            exit 1
+          fi
           echo "committed=true" >> "$GITHUB_OUTPUT"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -98,6 +103,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}
@@ -123,6 +133,11 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
+      - name: Block on lockfile repair failure
+        if: ${{ needs.update-lockfile.result == 'failure' }}
+        shell: bash
+        run: |
+          echo "::error::update-lockfile failed to repair uv.lock - run 'uv lock' locally and push." && exit 1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.update-lockfile.outputs.committed == 'true' && github.head_ref || '' }}


### PR DESCRIPTION
Fixes the broken Dependabot `update-lockfile` repair path (issue #93).

## Changes
- **Avoid the argv limit.** `uv.lock` (~360 KB → ~480 KB base64) was passed as one `gh api graphql` argument, exceeding Linux `MAX_ARG_STRLEN` (128 KB/arg) → "Argument list too long" (exit 126) on any real drift. The base64 now lives only in files.
- **Fix the createCommitOnBranch payload.** Staging verification revealed the commit was *also* broken independently of the argv issue: the `gh ... -f "input[...][...]"` bracket notation built `input[branchRef]` (wrong field — schema is `branch`) and `fileChanges.additions[0]` as an object `{"0":{...}}` instead of the required list, so the mutation returned `{"data":null}`, created no commit, and still exited 0. The request is now built as JSON with `jq` (correct `branch` field, `additions` as an array) and passed via `gh api graphql --input`. A response check fails the step loudly if no commit oid is returned.
- **Loud-fail guard.** `lint`/`typecheck`/`test` get a first-step guard (before checkout) that goes **red** when `update-lockfile` fails, so a failed repair is merge-blocking and never leaves a green run on a stale head. (A *skipped* required job reports Success, so the guard must fire as a red step, not via `if:`.) `Protect main` ruleset unchanged.

## Verification
End-to-end staging run on a throwaway PR (test-only actor-gate relaxation, forced `uv.lock` drift):
- `update-lockfile` regenerated the lock and `createCommitOnBranch` pushed a **verified** repair commit (`shared-workflows-release-bot[bot]`) — no "Argument list too long", no `{"data":null}`.
- The App-token push triggered a **fresh** CI run; `concurrency: cancel-in-progress` cancelled the stale run.
- All required checks (`lint`, `typecheck`, `test` ×9, `dependency-safety / gate`) passed on the **repaired head**.
- The committed lockfile passed `uv lock --check` (clean base64 round-trip).

Fixes #93.