### PR TITLE
build(deps): bump shared-workflows tag-release to v3.0.1

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@a8655fe2f5fb3aabfe5531b283956c683ba3029b # v3.0.0
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
## What

Pin `tag-release.yml` to commit `522610f` (**v3.0.1**) — the same SHA already used by `dependency-safety.yml`.

## Why

The two callers of `j7an/shared-workflows` had drifted apart:

| Caller | Was | Now |
|--------|-----|-----|
| `dependency-safety.yml` | v3.0.1 | v3.0.1 |
| `tag-release.yml` | v2.5.3 | **v3.0.1** |

Dependabot PR #109 stopped at **v3.0.0** because v3.0.1 (released 2026-05-28) was still inside the github-actions `cooldown.default-days: 5` window when that PR ran. This lands v3.0.1 directly and closes the gap.

## Safety

The v3.0.1 `workflow_call` interface accepts exactly the inputs this caller passes (`bump`, `tag-prefix`, secret `RELEASE_BOT_PRIVATE_KEY`) — verified against the tag. SHA dereferenced from the **commit** (`522610f`), not the annotated-tag object.

Refs #109