### PR TITLE
fix(ci): drift canary uses built-in GITHUB_TOKEN instead of a managed PAT

### DIFF
--- a/.github/workflows/scraper-drift-check.yml
+++ b/.github/workflows/scraper-drift-check.yml
@@ -16,5 +16,12 @@ jobs:
       - uses: ./.github/actions/setup-uv  # installs uv + runs `uv sync --locked`
       - name: Run drift check
         env:
-          DRIFT_CHECK_TOKEN: ${{ secrets.DRIFT_CHECK_TOKEN }}
+          # The drift canary only needs an *authenticated identity* to raise
+          # github.com's anonymous HTML rate limit (scraper.py sends it as
+          # `Authorization: token`). It needs no scopes and never touches private
+          # data, so the per-run, auto-rotated GITHUB_TOKEN is preferred over a
+          # hand-managed PAT — no expiry to track. If GitHub ever stops honoring
+          # GITHUB_TOKEN for HTML rate-limiting, the scrape degrades to
+          # RATE_LIMITED → exit 0 + `::warning::` (inconclusive), never a hard fail.
+          DRIFT_CHECK_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run python -m dep_rank.scripts.drift_check


### PR DESCRIPTION
## Problem

The scheduled **Scraper Drift Check** went red ([run 26752401125](https://github.com/j7an/dep-rank/actions/runs/26752401125)). Root cause: the `DRIFT_CHECK_TOKEN` repo secret was **never created**, so `${{ secrets.DRIFT_CHECK_TOKEN }}` resolved to an empty string and the script's intentional fail-loud guard (`drift_check.py:62-73`) exited 2. This would have recurred every Monday.

## Why GITHUB_TOKEN instead of adding a PAT

The canary only needs an **authenticated identity** to lift github.com's anonymous HTML rate limit — `scraper.py:494` sends the token as `Authorization: token <token>` on the dependents-page requests. It needs **no scopes** and reads only public HTML.

A hand-rolled PAT would mean a recurring expiry/rotation chore (and fine-grained PATs cap at ~1 year). The Actions-provided `GITHUB_TOKEN` is minted per-run and auto-rotated — **nothing to manage, nothing to expire.**

Fail-safe: if GitHub ever stops honoring `GITHUB_TOKEN` for HTML rate-limiting, the scrape degrades to `RATE_LIMITED` → exit 0 + `::warning::` (inconclusive), never a hard CI failure.

## Empirical verification

Dispatched this branch via `workflow_dispatch` ([run 26793960025](https://github.com/j7an/dep-rank/actions/runs/26793960025)) — passed with the genuine healthy verdict, not the inconclusive fallback:

```
OK: 10 repos parsed, 2733180 total dependents reported (stop reason: max_pages_reached).
```

`max_pages_reached` (not `RATE_LIMITED`) confirms `GITHUB_TOKEN` successfully authenticated the HTML requests and the selectors parse.

Refs #74