### PR TITLE
feat(trust): add opt-in --rank-by trust for dependent repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Responses are cached in a local SQLite database (`~/.cache/dep-rank/`) with ETag
 `dep-rank deps --rank-by trust` re-ranks dependents by a lightweight composite
 score instead of raw stars. Stars are useful but [gameable][starscout]; trust
 ranking blends stars with non-star signals — forks, total issues and pull
-requests, and recency of activity — fetched in a single low-cost GitHub GraphQL
-query.
+requests, and recency of activity — fetched via low-cost GitHub GraphQL queries
+(batched at 100 repositories per request, so a larger pool issues more than one).
 
 ```bash
 dep-rank deps https://github.com/django/django --rank-by trust --token ghp_...

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ dep-rank deps https://github.com/django/django --packages
 | `--max-pages` | 200 | Maximum pages to scrape (ceiling 1000) |
 | `--concurrency` | 3 | Max concurrent page fetches (1–10) |
 | `--no-adaptive-stop` | off | Disable adaptive early-stop; scrape continues until exhaustion or `--max-pages` |
+| `--rank-by` | stars | Ranking strategy: `stars` or `trust` (heuristic, requires token) |
 
 ### `dep-rank search` — Search code in dependents
 
@@ -81,6 +82,7 @@ A token is effectively required for non-trivial use: unauthenticated GitHub HTML
 
 **What requires a token:**
 - `--descriptions` flag — fetches repo descriptions via GitHub GraphQL API
+- `--rank-by trust` — fetches engagement/recency metadata via GitHub GraphQL API
 - `dep-rank search` — code search across dependents
 
 Create a token at [github.com/settings/tokens](https://github.com/settings/tokens) with `public_repo` scope.
@@ -94,6 +96,39 @@ dep-rank uses a three-stage pipeline:
 3. **Present** — returns structured results as a Rich table
 
 Responses are cached in a local SQLite database (`~/.cache/dep-rank/`) with ETag support for conditional requests. Expired pages are served immediately and refreshed in the background (stale-while-revalidate) on authenticated runs.
+
+## Trust Ranking
+
+`dep-rank deps --rank-by trust` re-ranks dependents by a lightweight composite
+score instead of raw stars. Stars are useful but [gameable][starscout]; trust
+ranking blends stars with non-star signals — forks, total issues and pull
+requests, and recency of activity — fetched in a single low-cost GitHub GraphQL
+query.
+
+```bash
+dep-rank deps https://github.com/django/django --rank-by trust --token ghp_...
+```
+
+**Important caveats:**
+
+- The score is a **pool-relative ranking signal, not an absolute quality score** —
+  it min-max normalizes signals across the scraped candidate set.
+- It re-ranks **only the scraped candidate pool** (the star-top-N dependents), not
+  every dependent.
+- It is **heuristic and does not detect fake stars.** It does not fetch stargazer
+  history, GHArchive data, or external fraud datasets.
+- Trust ranking scrapes a **larger candidate pool and is therefore deeper and
+  slower** than star ranking.
+- `--rank-by trust` requires a GitHub token; trust scores appear in `--format json`
+  output under each repo's `trust` field.
+
+Motivation that stars are gameable comes from **StarScout** ([repo][starscout],
+[preprint](https://arxiv.org/abs/2412.13459),
+[ICSE 2026](https://conf.researchr.org/details/icse-2026/icse-2026-research-track/14/Six-Million-Suspected-Fake-Stars-on-GitHub-A-Growing-Spiral-of-Popularity-Contests)).
+The low-resource API basis is the
+[GitHub GraphQL rate-limit docs](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api).
+
+[starscout]: https://github.com/hehao98/StarScout
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dep-rank
 
-Rank GitHub dependents by stars.
+Rank GitHub dependents by stars or trust.
 
 [![PyPI](https://img.shields.io/pypi/v/dep-rank)](https://pypi.org/project/dep-rank/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dep-rank"
 dynamic = ["version"]
-description = "Analyze GitHub repository dependents by star count."
+description = "Analyze GitHub repository dependents, ranked by stars or trust."
 requires-python = ">=3.11"
 license = "MIT"
 authors = [

--- a/src/dep_rank/__init__.py
+++ b/src/dep_rank/__init__.py
@@ -1,4 +1,4 @@
-"""dep-rank: Analyze GitHub repository dependents by star count."""
+"""dep-rank: Analyze GitHub repository dependents, ranked by stars or trust."""
 
 from importlib.metadata import version
 

--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import sys
 from datetime import UTC, datetime
+from typing import Literal
 
 import appdirs
 import click
@@ -111,16 +112,18 @@ async def run_deps(
 
                     console.print(partial_warning(scrape_result.reason))
 
-            ranked_by = "stars"
-            if rank_by == "trust":
+            ranked_by: Literal["stars", "trust"] = "stars"
+            # ``and token`` makes the token precondition explicit (the CLI preflight
+            # already enforces it) and narrows the type for the enrich call. A direct
+            # caller passing rank_by="trust" without a token degrades to star ranking.
+            if rank_by == "trust" and token:
                 from dep_rank.core.graphql import enrich_with_trust_metadata
                 from dep_rank.core.trust import compute_trust_scores
 
-                # token presence guaranteed by the CLI preflight check.
                 meta = await enrich_with_trust_metadata(
                     session,
                     repos,
-                    token,  # type: ignore[arg-type]
+                    token,
                     include_description=descriptions,
                     cache=cache,
                 )
@@ -227,7 +230,7 @@ def deps(
     adaptive_stop: bool,
     rank_by: str,
 ) -> None:
-    """List top dependents of a GitHub repository, ranked by stars."""
+    """List top dependents of a GitHub repository, ranked by stars (default) or trust."""
     try:
         validate_github_url(url)
     except ValueError as e:

--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -170,7 +170,7 @@ async def run_deps(
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose/debug logging.")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:
-    """Analyze GitHub repository dependents by star count."""
+    """Analyze GitHub repository dependents, ranked by stars or trust."""
     ctx.ensure_object(dict)
     ctx.obj["verbose"] = verbose
     if verbose:

--- a/src/dep_rank/cli/app.py
+++ b/src/dep_rank/cli/app.py
@@ -34,6 +34,7 @@ async def run_deps(
     concurrency: int = 3,
     adaptive_stop: bool = True,
     quiet: bool = False,
+    rank_by: str = "stars",
 ) -> DependentsResult:
     """Run the deps pipeline: scrape → enrich → return."""
     import aiohttp
@@ -69,6 +70,10 @@ async def run_deps(
                 if live is not None:
                     live.update(build_topk_table(snapshot))
 
+            scrape_rows = rows
+            if rank_by == "trust":
+                scrape_rows = 0 if rows <= 0 else max(rows, min(100, rows * 10))
+
             if live is not None:
                 live.start()
             try:
@@ -80,7 +85,7 @@ async def run_deps(
                     cache=cache,
                     token=token,
                     max_pages=max_pages,
-                    rows=rows,
+                    rows=scrape_rows,
                     concurrency=concurrency,
                     adaptive_stop=adaptive_stop,
                     on_partial=on_partial,
@@ -106,11 +111,39 @@ async def run_deps(
 
                     console.print(partial_warning(scrape_result.reason))
 
-            repos = repos[:rows]
+            ranked_by = "stars"
+            if rank_by == "trust":
+                from dep_rank.core.graphql import enrich_with_trust_metadata
+                from dep_rank.core.trust import compute_trust_scores
 
-            if descriptions and token and repos:
-                repos = await enrich_with_graphql(session, repos, token, cache=cache)
+                # token presence guaranteed by the CLI preflight check.
+                meta = await enrich_with_trust_metadata(
+                    session,
+                    repos,
+                    token,  # type: ignore[arg-type]
+                    include_description=descriptions,
+                    cache=cache,
+                )
+                if meta.failed:
+                    if not quiet:
+                        console.print(
+                            "[yellow]⚠ Trust metadata fetch failed — "
+                            "falling back to star ranking.[/yellow]"
+                        )
+                    repos = sorted(meta.repos, key=lambda r: r.stars, reverse=True)[:rows]
+                else:
+                    if not meta.complete and not quiet:
+                        console.print(
+                            "[yellow]⚠ Some trust metadata was missing — "
+                            "scores use partial data.[/yellow]"
+                        )
+                    repos = compute_trust_scores(meta.repos)[:rows]
+                    ranked_by = "trust"
+            else:
                 repos = repos[:rows]
+                if descriptions and token and repos:
+                    repos = await enrich_with_graphql(session, repos, token, cache=cache)
+                    repos = repos[:rows]
 
             return DependentsResult(
                 source=url,
@@ -123,6 +156,7 @@ async def run_deps(
                 reason=scrape_result.reason,
                 pages_scraped=scrape_result.pages_scraped,
                 estimated_total_pages=scrape_result.estimated_total_pages,
+                ranked_by=ranked_by,
             )
     finally:
         await cache.close()
@@ -172,6 +206,12 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     default=True,
     help="Stop early when recent pages can no longer change the top-K (default: on).",
 )
+@click.option(
+    "--rank-by",
+    type=click.Choice(["stars", "trust"]),
+    default="stars",
+    help="Ranking strategy: stars (default) or trust (heuristic, requires token).",
+)
 @click.pass_context
 def deps(
     ctx: click.Context,
@@ -185,6 +225,7 @@ def deps(
     max_pages: int,
     concurrency: int,
     adaptive_stop: bool,
+    rank_by: str,
 ) -> None:
     """List top dependents of a GitHub repository, ranked by stars."""
     try:
@@ -196,6 +237,13 @@ def deps(
     if descriptions and not token:
         click.echo(
             "Error: --descriptions requires a GitHub token (--token or DEP_RANK_TOKEN env var)",
+            err=True,
+        )
+        sys.exit(1)
+
+    if rank_by == "trust" and not token:
+        click.echo(
+            "Error: --rank-by trust requires a GitHub token (--token or DEP_RANK_TOKEN env var)",
             err=True,
         )
         sys.exit(1)
@@ -226,13 +274,14 @@ def deps(
             concurrency=concurrency,
             adaptive_stop=adaptive_stop,
             quiet=(output_format == "json"),
+            rank_by=rank_by,
         )
     )
 
     from dep_rank.cli.formatters import print_dependents_json, print_dependents_table
 
     if output_format == "json":
-        print_dependents_json(result)
+        print_dependents_json(result, include_rank_metadata=(rank_by == "trust"))
     else:
         print_dependents_table(result)
 

--- a/src/dep_rank/cli/formatters.py
+++ b/src/dep_rank/cli/formatters.py
@@ -24,7 +24,14 @@ def humanize(num: int) -> str:
 
 
 def print_dependents_table(result: DependentsResult) -> None:
-    """Print a Rich table of dependents."""
+    """Print a Rich table of dependents, dispatching on the ranking actually applied."""
+    if result.ranked_by == "trust":
+        _print_trust_table(result)
+    else:
+        _print_star_table(result)
+
+
+def _print_star_table(result: DependentsResult) -> None:
     table = Table(title=f"Top dependents of {result.source}")
     table.add_column("Repository", style="cyan", no_wrap=True)
     table.add_column("Stars", justify="right", style="yellow")
@@ -46,9 +53,45 @@ def print_dependents_table(result: DependentsResult) -> None:
     )
 
 
-def print_dependents_json(result: DependentsResult) -> None:
-    """Print DependentsResult as JSON."""
-    console.print(result.model_dump_json(indent=2), highlight=False)
+def _print_trust_table(result: DependentsResult) -> None:
+    table = Table(title=f"Top dependents of {result.source} (by trust)")
+    table.add_column("Repository", style="cyan", no_wrap=True)
+    table.add_column("Trust", justify="right", style="magenta")
+    table.add_column("Stars", justify="right", style="yellow")
+
+    has_descriptions = any(r.description for r in result.repos)
+    if has_descriptions:
+        table.add_column("Description", style="dim")
+
+    for repo in result.repos:
+        score = round(repo.trust.score) if repo.trust else 0
+        row = [f"{repo.owner}/{repo.name}", str(score), humanize(repo.stars)]
+        if has_descriptions:
+            row.append(repo.description or "")
+        table.add_row(*row)
+
+    console.print(table)
+    console.print(
+        f"\n[dim]{result.total_count:,} total dependents, "
+        f"{result.filtered_count:,} with stars above threshold[/dim]"
+    )
+
+
+def print_dependents_json(result: DependentsResult, *, include_rank_metadata: bool = False) -> None:
+    """Print DependentsResult as JSON.
+
+    Star mode (``include_rank_metadata=False``) excludes ``ranked_by`` and per-repo
+    ``trust`` so CLI output stays byte-identical to pre-trust-ranking releases. Trust
+    mode includes both. ``trust_signals`` is excluded structurally by the model field.
+    """
+    if include_rank_metadata:
+        payload = result.model_dump_json(indent=2)
+    else:
+        payload = result.model_dump_json(
+            indent=2,
+            exclude={"ranked_by": True, "repos": {"__all__": {"trust"}}},
+        )
+    console.print(payload, highlight=False)
 
 
 def print_search_results(result: CodeSearchResult) -> None:

--- a/src/dep_rank/core/graphql.py
+++ b/src/dep_rank/core/graphql.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from typing import Any
 
 import aiohttp
 
 from dep_rank.core.cache import SqliteCache
-from dep_rank.core.models import Repository
+from dep_rank.core.models import Repository, TrustMetadataResult, TrustSignals
 
 logger = logging.getLogger(__name__)
 
@@ -85,3 +87,120 @@ async def enrich_with_graphql(
 
     enriched.sort(key=lambda r: r.stars, reverse=True)
     return enriched
+
+
+def build_trust_query(repos: list[Repository], *, include_description: bool) -> str:
+    """Build a GraphQL query for trust metadata across multiple repos.
+
+    Fetches accurate stars plus low-cost engagement/recency signals. The ``states:``
+    filters are stated explicitly (exhaustive enums) so the intent — all-time totals —
+    cannot drift. When ``include_description`` is set, also fetches description so a
+    combined ``--rank-by trust --descriptions`` run needs only one GraphQL pass.
+    """
+    desc = " description" if include_description else ""
+    fragments: list[str] = []
+    for i, repo in enumerate(repos):
+        fragments.append(
+            f'repo_{i}: repository(owner: "{repo.owner}", name: "{repo.name}") {{ '
+            f"stargazerCount forkCount "
+            f"issues(states: [OPEN, CLOSED]) {{ totalCount }} "
+            f"pullRequests(states: [OPEN, CLOSED, MERGED]) {{ totalCount }} "
+            f"pushedAt{desc} }}"
+        )
+    return "query { " + " ".join(fragments) + " }"
+
+
+def _apply_trust_data(
+    repo: Repository, repo_data: dict[str, Any], include_description: bool
+) -> Repository:
+    """Return a copy of ``repo`` updated with accurate stars + trust signals."""
+    pushed_at_raw = repo_data.get("pushedAt")
+    pushed_at = datetime.fromisoformat(pushed_at_raw) if pushed_at_raw else None
+    signals = TrustSignals(
+        forks=repo_data.get("forkCount"),
+        issues=(repo_data.get("issues") or {}).get("totalCount"),
+        pull_requests=(repo_data.get("pullRequests") or {}).get("totalCount"),
+        pushed_at=pushed_at,
+    )
+    stars = repo_data.get("stargazerCount")
+    update: dict[str, Any] = {
+        # Sparse/field-errored repo objects may omit stargazerCount — degrade to the
+        # scraped value rather than crash (graceful partial handling).
+        "stars": stars if stars is not None else repo.stars,
+        "trust_signals": signals,
+    }
+    if include_description:
+        update["description"] = repo_data.get("description")
+    return repo.model_copy(update=update)
+
+
+async def enrich_with_trust_metadata(
+    session: aiohttp.ClientSession,
+    repos: list[Repository],
+    token: str,
+    *,
+    include_description: bool = False,
+    cache: SqliteCache | None = None,
+) -> TrustMetadataResult:
+    """Fetch trust metadata for repos via GraphQL (batches of 100).
+
+    Status semantics: a 401 short-circuits to ``failed=True`` (token invalid). Ordinary
+    batch errors (non-200 / GraphQL error) make those repos pass through with
+    ``trust_signals=None`` and set ``complete=False``; they only make ``failed=True``
+    when every batch fails. ``complete`` is True only on a clean run.
+    """
+    if not repos:
+        return TrustMetadataResult(repos=[], failed=False, complete=True)
+
+    headers = {
+        "Authorization": f"bearer {token}",
+        "Content-Type": "application/json",
+    }
+    enriched: list[Repository] = []
+    any_success = False
+    complete = True
+
+    for batch_start in range(0, len(repos), BATCH_SIZE):
+        batch = repos[batch_start : batch_start + BATCH_SIZE]
+        query = build_trust_query(batch, include_description=include_description)
+
+        async with session.post(
+            GRAPHQL_URL,
+            json={"query": query},
+            headers=headers,
+        ) as resp:
+            if resp.status == 401:
+                logger.warning("GitHub API authentication failed — token may be expired or invalid")
+                return TrustMetadataResult(repos=repos, failed=True, complete=False)
+            if resp.status != 200:
+                logger.warning("GitHub API returned HTTP %d", resp.status)
+                enriched.extend(batch)
+                complete = False
+                continue
+            data = await resp.json()
+
+        if "data" not in data or data["data"] is None:
+            message = data.get("message") or data.get("errors", "unknown error")
+            logger.warning("GitHub GraphQL error: %s", message)
+            enriched.extend(batch)
+            complete = False
+            continue
+
+        if data.get("errors"):
+            # Partial response: usable data alongside per-repo/per-field errors. Keep
+            # the data but mark the run incomplete (spec: GraphQL error -> complete=False).
+            logger.warning("GitHub GraphQL partial errors: %s", data["errors"])
+            complete = False
+
+        for i, repo in enumerate(batch):
+            repo_data = data["data"].get(f"repo_{i}")
+            if not repo_data:
+                enriched.append(repo)
+                complete = False
+                continue
+            enriched.append(_apply_trust_data(repo, repo_data, include_description))
+            # success means a repo got usable trust_signals, not merely a data object
+            any_success = True
+
+    failed = not any_success
+    return TrustMetadataResult(repos=enriched, failed=failed, complete=complete and not failed)

--- a/src/dep_rank/core/graphql.py
+++ b/src/dep_rank/core/graphql.py
@@ -115,7 +115,19 @@ def _apply_trust_data(
 ) -> Repository:
     """Return a copy of ``repo`` updated with accurate stars + trust signals."""
     pushed_at_raw = repo_data.get("pushedAt")
-    pushed_at = datetime.fromisoformat(pushed_at_raw) if pushed_at_raw else None
+    pushed_at = None
+    if pushed_at_raw:
+        try:
+            pushed_at = datetime.fromisoformat(pushed_at_raw)
+        except ValueError:
+            # A malformed timestamp degrades recency to "missing" rather than aborting
+            # the whole trust run — consistent with the function's other partial handling.
+            logger.warning(
+                "Unparseable pushedAt %r for %s/%s — treating recency as missing",
+                pushed_at_raw,
+                repo.owner,
+                repo.name,
+            )
     signals = TrustSignals(
         forks=repo_data.get("forkCount"),
         issues=(repo_data.get("issues") or {}).get("totalCount"),

--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 class DependentType(StrEnum):
@@ -28,6 +28,39 @@ class ScrapeReason(StrEnum):
     RATE_LIMITED = "rate_limited"
 
 
+class TrustSignals(BaseModel):
+    """Raw repository metadata fetched for trust scoring.
+
+    Transient, pre-score carrier between the GraphQL fetch and the scorer; never
+    serialized (the field that holds it is excluded).
+    """
+
+    forks: int | None = None
+    issues: int | None = None  # total issues (all-time)
+    pull_requests: int | None = None  # total pull requests (all-time)
+    pushed_at: datetime | None = None
+
+
+class TrustComponents(BaseModel):
+    """Pool-normalized component scores, each 0.0-1.0."""
+
+    stars: float
+    forks: float
+    engagement: float  # issues + pull requests
+    recency: float
+
+
+class TrustScore(BaseModel):
+    """Final trust score plus raw signals and the component breakdown (serialized)."""
+
+    score: float  # 0-100, pool-relative
+    forks: int | None = None
+    issues: int | None = None
+    pull_requests: int | None = None
+    pushed_at: datetime | None = None
+    components: TrustComponents
+
+
 class Repository(BaseModel):
     """A GitHub repository that depends on the target repo."""
 
@@ -36,6 +69,8 @@ class Repository(BaseModel):
     url: str
     stars: int
     description: str | None = None
+    trust_signals: TrustSignals | None = Field(default=None, exclude=True)
+    trust: TrustScore | None = None
 
 
 class ScrapeResult(BaseModel):
@@ -88,6 +123,7 @@ class DependentsResult(BaseModel):
     reason: ScrapeReason | None = None
     pages_scraped: int = 0
     estimated_total_pages: int = 0
+    ranked_by: str = "stars"
 
     @model_validator(mode="after")
     def _check_complete_reason_invariant(self) -> DependentsResult:
@@ -113,3 +149,16 @@ class CodeSearchResult(BaseModel):
     query: str
     hits: list[CodeSearchHit]
     searched_repos: int
+
+
+class TrustMetadataResult(BaseModel):
+    """Return type of the trust-metadata fetch, carrying fetch status.
+
+    ``failed=True`` means no usable metadata was obtained (a 401, or every batch
+    errored) and the caller should fall back to star ranking. ``complete`` is True
+    only when every requested repo received signals.
+    """
+
+    repos: list[Repository]
+    failed: bool
+    complete: bool

--- a/src/dep_rank/core/models.py
+++ b/src/dep_rank/core/models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -123,7 +124,7 @@ class DependentsResult(BaseModel):
     reason: ScrapeReason | None = None
     pages_scraped: int = 0
     estimated_total_pages: int = 0
-    ranked_by: str = "stars"
+    ranked_by: Literal["stars", "trust"] = "stars"
 
     @model_validator(mode="after")
     def _check_complete_reason_invariant(self) -> DependentsResult:

--- a/src/dep_rank/core/trust.py
+++ b/src/dep_rank/core/trust.py
@@ -1,0 +1,106 @@
+"""Pure, deterministic trust scoring over a candidate pool.
+
+The score is a pool-relative ranking signal (0-100), not an absolute quality
+measure. Pool-relative recency is a min-max over ``pushed_at`` and never references
+the clock, so this module is fully deterministic and needs no ``now`` parameter.
+"""
+
+from __future__ import annotations
+
+import math
+
+from dep_rank.core.models import Repository, TrustComponents, TrustScore
+
+# Component weights (sum to 1.0). Stars <= 0.40; non-star signals are the majority.
+_W_STARS = 0.35
+_W_FORKS = 0.25
+_W_ENGAGEMENT = 0.20
+_W_RECENCY = 0.20
+
+
+def _minmax(values: list[float]) -> list[float]:
+    """Min-max normalize to 0.0-1.0. Degenerate (all equal) -> 0.5 for every element."""
+    lo = min(values)
+    hi = max(values)
+    if hi == lo:
+        return [0.5] * len(values)
+    span = hi - lo
+    return [(v - lo) / span for v in values]
+
+
+def _log_component(raws: list[int]) -> list[float]:
+    """log1p each raw count, then min-max. Missing raws must already be 0."""
+    return _minmax([math.log1p(v) for v in raws])
+
+
+def _recency_component(repos: list[Repository]) -> list[float]:
+    """Pool-relative recency from ``pushed_at``.
+
+    Missing ``pushed_at`` is forced to 0.0 and never enters the min-max. Present
+    timestamps are min-max'd; a degenerate present range yields 0.5 for those repos.
+    """
+    result = [0.0] * len(repos)
+    present: list[tuple[int, float]] = []
+    for i, repo in enumerate(repos):
+        sig = repo.trust_signals
+        if sig is not None and sig.pushed_at is not None:
+            present.append((i, sig.pushed_at.timestamp()))
+    if not present:
+        return result
+    normed = _minmax([epoch for _, epoch in present])
+    for (i, _), value in zip(present, normed, strict=True):
+        result[i] = value
+    return result
+
+
+def compute_trust_scores(repos: list[Repository]) -> list[Repository]:
+    """Score each repo 0-100 relative to the pool; return them sorted by score desc.
+
+    Repos should carry ``trust_signals``; missing signals are scored as weak (counts
+    -> 0 before normalization, missing ``pushed_at`` -> 0.0 recency). Ties break by
+    stars desc, then ``owner/name`` ascending, for stable ordering.
+    """
+    if not repos:
+        return []
+
+    stars_c = _log_component([r.stars for r in repos])
+    forks_c = _log_component(
+        [(r.trust_signals.forks or 0) if r.trust_signals else 0 for r in repos]
+    )
+    engagement_c = _log_component(
+        [
+            ((r.trust_signals.issues or 0) + (r.trust_signals.pull_requests or 0))
+            if r.trust_signals
+            else 0
+            for r in repos
+        ]
+    )
+    recency_c = _recency_component(repos)
+
+    scored: list[tuple[float, Repository]] = []
+    for i, repo in enumerate(repos):
+        components = TrustComponents(
+            stars=stars_c[i],
+            forks=forks_c[i],
+            engagement=engagement_c[i],
+            recency=recency_c[i],
+        )
+        score = 100.0 * (
+            _W_STARS * components.stars
+            + _W_FORKS * components.forks
+            + _W_ENGAGEMENT * components.engagement
+            + _W_RECENCY * components.recency
+        )
+        sig = repo.trust_signals
+        trust = TrustScore(
+            score=score,
+            forks=sig.forks if sig else None,
+            issues=sig.issues if sig else None,
+            pull_requests=sig.pull_requests if sig else None,
+            pushed_at=sig.pushed_at if sig else None,
+            components=components,
+        )
+        scored.append((score, repo.model_copy(update={"trust": trust})))
+
+    scored.sort(key=lambda t: (-t[0], -t[1].stars, f"{t[1].owner}/{t[1].name}"))
+    return [repo for _, repo in scored]

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -564,3 +564,238 @@ class TestDepsLiveTopK:
         assert "delta/app" in result.output
         # Live.update fired at least once per page snapshot (>=2).
         assert mock_live_update.call_count >= 2
+
+
+class TestRankByTrust:
+    def _scrape_result(self, repos: list[Repository]) -> ScrapeResult:
+        return ScrapeResult(
+            repos=repos,
+            pages_scraped=1,
+            max_pages=1000,
+            estimated_total_pages=30,
+            estimated_total_dependents=900,
+            matched_count=len(repos),
+        )
+
+    def test_trust_without_token_errors(self, runner: CliRunner) -> None:
+        result = runner.invoke(
+            cli, ["deps", "https://github.com/django/django", "--rank-by", "trust"]
+        )
+        assert result.exit_code != 0
+        assert "requires a GitHub token" in result.output
+
+    @pytest.mark.parametrize(
+        ("rows", "expected_pool"),
+        [(0, 0), (5, 50), (10, 100), (50, 100), (200, 200)],
+    )
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_trust_pool_size_formula(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+        rows: int,
+        expected_pool: int,
+    ) -> None:
+        # pool_size = 0 if rows <= 0 else max(rows, min(100, rows * 10))
+        from dep_rank.core.models import TrustMetadataResult
+
+        repos = [Repository(owner="a", name="b", url="https://github.com/a/b", stars=10)]
+        mock_scrape.return_value = self._scrape_result(repos)
+        with patch(
+            "dep_rank.core.graphql.enrich_with_trust_metadata", new_callable=AsyncMock
+        ) as mock_trust:
+            mock_trust.return_value = TrustMetadataResult(repos=repos, failed=False, complete=True)
+            result = runner.invoke(
+                cli,
+                [
+                    "deps",
+                    "https://github.com/django/django",
+                    "--token",
+                    "ghp_x",
+                    "--rank-by",
+                    "trust",
+                    "--rows",
+                    str(rows),
+                ],
+            )
+        assert result.exit_code == 0
+        _, kwargs = mock_scrape.call_args
+        assert kwargs["rows"] == expected_pool
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_trust_json_includes_metadata(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        import json
+
+        from dep_rank.core.models import TrustMetadataResult
+
+        repos = [
+            Repository(owner="a", name="b", url="https://github.com/a/b", stars=10),
+            Repository(owner="c", name="d", url="https://github.com/c/d", stars=20),
+        ]
+        mock_scrape.return_value = self._scrape_result(repos)
+        with patch(
+            "dep_rank.core.graphql.enrich_with_trust_metadata", new_callable=AsyncMock
+        ) as mock_trust:
+            mock_trust.return_value = TrustMetadataResult(repos=repos, failed=False, complete=True)
+            result = runner.invoke(
+                cli,
+                [
+                    "deps",
+                    "https://github.com/django/django",
+                    "--token",
+                    "ghp_x",
+                    "--rank-by",
+                    "trust",
+                    "--format",
+                    "json",
+                ],
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["ranked_by"] == "trust"
+        assert payload["repos"][0]["trust"] is not None
+        assert "score" in payload["repos"][0]["trust"]
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_trust_fetch_failure_falls_back_to_stars(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        import json
+
+        from dep_rank.core.models import TrustMetadataResult
+
+        repos = [Repository(owner="a", name="b", url="https://github.com/a/b", stars=10)]
+        mock_scrape.return_value = self._scrape_result(repos)
+        with patch(
+            "dep_rank.core.graphql.enrich_with_trust_metadata", new_callable=AsyncMock
+        ) as mock_trust:
+            mock_trust.return_value = TrustMetadataResult(repos=repos, failed=True, complete=False)
+            result = runner.invoke(
+                cli,
+                [
+                    "deps",
+                    "https://github.com/django/django",
+                    "--token",
+                    "ghp_x",
+                    "--rank-by",
+                    "trust",
+                    "--format",
+                    "json",
+                ],
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["ranked_by"] == "stars"  # honest fallback
+        assert payload["repos"][0]["trust"] is None
+
+    def test_star_json_unchanged_has_no_rank_metadata(self, runner: CliRunner) -> None:
+        import json
+
+        with patch("dep_rank.cli.app.run_deps", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = DependentsResult(
+                source="https://github.com/django/django",
+                total_count=1,
+                filtered_count=1,
+                repos=[Repository(owner="a", name="b", url="https://github.com/a/b", stars=10)],
+                dependent_type=DependentType.REPOSITORY,
+                scraped_at=datetime.now(tz=UTC),
+            )
+            result = runner.invoke(
+                cli, ["deps", "https://github.com/django/django", "--format", "json"]
+            )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert "ranked_by" not in payload
+        assert "trust" not in result.stdout
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_fallback_emits_warning_in_table_mode(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        from dep_rank.core.models import TrustMetadataResult
+
+        repos = [Repository(owner="a", name="b", url="https://github.com/a/b", stars=10)]
+        mock_scrape.return_value = self._scrape_result(repos)
+        with patch(
+            "dep_rank.core.graphql.enrich_with_trust_metadata", new_callable=AsyncMock
+        ) as mock_trust:
+            mock_trust.return_value = TrustMetadataResult(repos=repos, failed=True, complete=False)
+            result = runner.invoke(
+                cli,
+                [
+                    "deps",
+                    "https://github.com/django/django",
+                    "--token",
+                    "ghp_x",
+                    "--rank-by",
+                    "trust",
+                ],  # table mode (no --format json)
+            )
+        assert result.exit_code == 0
+        assert "falling back to star ranking" in result.output
+
+    @patch("dep_rank.cli.app.appdirs.user_cache_dir", return_value="/tmp/test-cache")  # noqa: S108
+    @patch("dep_rank.core.cache.SqliteCache.close", new_callable=AsyncMock)
+    @patch("dep_rank.core.cache.SqliteCache.initialize", new_callable=AsyncMock)
+    @patch("dep_rank.core.scraper.scrape_dependents", new_callable=AsyncMock)
+    def test_partial_metadata_emits_warning_in_table_mode(
+        self,
+        mock_scrape: AsyncMock,
+        mock_init: AsyncMock,
+        mock_close: AsyncMock,
+        mock_cache_dir: AsyncMock,
+        runner: CliRunner,
+    ) -> None:
+        from dep_rank.core.models import TrustMetadataResult
+
+        repos = [Repository(owner="a", name="b", url="https://github.com/a/b", stars=10)]
+        mock_scrape.return_value = self._scrape_result(repos)
+        with patch(
+            "dep_rank.core.graphql.enrich_with_trust_metadata", new_callable=AsyncMock
+        ) as mock_trust:
+            mock_trust.return_value = TrustMetadataResult(repos=repos, failed=False, complete=False)
+            result = runner.invoke(
+                cli,
+                [
+                    "deps",
+                    "https://github.com/django/django",
+                    "--token",
+                    "ghp_x",
+                    "--rank-by",
+                    "trust",
+                ],  # table mode
+            )
+        assert result.exit_code == 0
+        assert "partial data" in result.output

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -16,6 +16,8 @@ from dep_rank.core.models import (
     DependentsResult,
     DependentType,
     Repository,
+    TrustComponents,
+    TrustScore,
 )
 
 
@@ -246,3 +248,113 @@ class TestBuildTopKTable:
         out = cap.get()
         assert "page 3" in out
         assert "no matching repositories" in out.lower()
+
+
+class TestTrustTableAndJson:
+    def _trust_repo(self) -> Repository:
+        return Repository(
+            owner="alpha",
+            name="framework",
+            url="https://github.com/alpha/framework",
+            stars=12500,
+            trust=TrustScore(
+                score=87.4,
+                forks=900,
+                issues=300,
+                pull_requests=120,
+                pushed_at=None,
+                components=TrustComponents(stars=0.9, forks=0.8, engagement=0.7, recency=0.5),
+            ),
+        )
+
+    def _result(self, *, ranked_by: str, repos: list[Repository]) -> DependentsResult:
+        return DependentsResult(
+            source="https://github.com/django/django",
+            total_count=100,
+            filtered_count=50,
+            repos=repos,
+            dependent_type=DependentType.REPOSITORY,
+            scraped_at=datetime.now(tz=UTC),
+            ranked_by=ranked_by,
+        )
+
+    def test_trust_table_renders_score_and_stars(self) -> None:
+        import dep_rank.cli.formatters as fmt
+
+        result = self._result(ranked_by="trust", repos=[self._trust_repo()])
+        with fmt.console.capture() as cap:
+            fmt.print_dependents_table(result)
+        out = cap.get()
+        assert "alpha/framework" in out
+        assert "87" in out  # rounded trust score
+        assert "12K" in out or "12.5K" in out  # humanized stars
+
+    def test_fallback_renders_star_table(self) -> None:
+        # ranked_by == "stars" even though a star repo has no trust -> star layout.
+        import dep_rank.cli.formatters as fmt
+
+        star_repo = Repository(
+            owner="beta", name="toolkit", url="https://github.com/beta/toolkit", stars=3200
+        )
+        result = self._result(ranked_by="stars", repos=[star_repo])
+        with fmt.console.capture() as cap:
+            fmt.print_dependents_table(result)
+        out = cap.get()
+        assert "beta/toolkit" in out
+        assert "Trust" not in out  # no trust column in star/fallback layout
+
+    def test_json_star_mode_excludes_trust_and_ranked_by(self) -> None:
+        import dep_rank.cli.formatters as fmt
+
+        result = self._result(ranked_by="stars", repos=[self._trust_repo()])
+        with fmt.console.capture() as cap:
+            fmt.print_dependents_json(result, include_rank_metadata=False)
+        out = cap.get()
+        assert "ranked_by" not in out
+        assert "trust" not in out
+        assert "trust_signals" not in out
+
+    def test_json_star_mode_preserves_existing_fields_exactly(self) -> None:
+        # The printer — not raw model serialization — is the back-compat boundary.
+        # Prove pre-trust fields survive unchanged, including an explicit `null`
+        # description (the field must remain present, not be dropped by exclude_none).
+        import json
+
+        import dep_rank.cli.formatters as fmt
+
+        repo = Repository(
+            owner="alpha",
+            name="framework",
+            url="https://github.com/alpha/framework",
+            stars=12500,
+            description=None,  # must serialize as "description": null, not vanish
+        )
+        result = self._result(ranked_by="stars", repos=[repo])
+        with fmt.console.capture() as cap:
+            fmt.print_dependents_json(result, include_rank_metadata=False)
+        out = cap.get()
+        assert '"description": null' in out  # key present with explicit null
+        payload = json.loads(out)
+        assert payload["source"] == "https://github.com/django/django"
+        assert payload["total_count"] == 100
+        assert payload["filtered_count"] == 50
+        repo_json = payload["repos"][0]
+        assert repo_json == {
+            "owner": "alpha",
+            "name": "framework",
+            "url": "https://github.com/alpha/framework",
+            "stars": 12500,
+            "description": None,
+        }  # exact field set — no trust/trust_signals leakage, nothing dropped
+        assert "ranked_by" not in payload
+
+    def test_json_trust_mode_includes_metadata(self) -> None:
+        import dep_rank.cli.formatters as fmt
+
+        result = self._result(ranked_by="trust", repos=[self._trust_repo()])
+        with fmt.console.capture() as cap:
+            fmt.print_dependents_json(result, include_rank_metadata=True)
+        out = cap.get()
+        assert '"ranked_by": "trust"' in out
+        assert '"score": 87.4' in out
+        assert "trust_signals" not in out  # always excluded structurally

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from dep_rank.cli.formatters import (
+    console,
     format_scrape_summary,
     humanize,
+    print_dependents_json,
     print_dependents_table,
     print_search_results,
 )
@@ -279,11 +281,9 @@ class TestTrustTableAndJson:
         )
 
     def test_trust_table_renders_score_and_stars(self) -> None:
-        import dep_rank.cli.formatters as fmt
-
         result = self._result(ranked_by="trust", repos=[self._trust_repo()])
-        with fmt.console.capture() as cap:
-            fmt.print_dependents_table(result)
+        with console.capture() as cap:
+            print_dependents_table(result)
         out = cap.get()
         assert "alpha/framework" in out
         assert "87" in out  # rounded trust score
@@ -291,24 +291,20 @@ class TestTrustTableAndJson:
 
     def test_fallback_renders_star_table(self) -> None:
         # ranked_by == "stars" even though a star repo has no trust -> star layout.
-        import dep_rank.cli.formatters as fmt
-
         star_repo = Repository(
             owner="beta", name="toolkit", url="https://github.com/beta/toolkit", stars=3200
         )
         result = self._result(ranked_by="stars", repos=[star_repo])
-        with fmt.console.capture() as cap:
-            fmt.print_dependents_table(result)
+        with console.capture() as cap:
+            print_dependents_table(result)
         out = cap.get()
         assert "beta/toolkit" in out
         assert "Trust" not in out  # no trust column in star/fallback layout
 
     def test_json_star_mode_excludes_trust_and_ranked_by(self) -> None:
-        import dep_rank.cli.formatters as fmt
-
         result = self._result(ranked_by="stars", repos=[self._trust_repo()])
-        with fmt.console.capture() as cap:
-            fmt.print_dependents_json(result, include_rank_metadata=False)
+        with console.capture() as cap:
+            print_dependents_json(result, include_rank_metadata=False)
         out = cap.get()
         assert "ranked_by" not in out
         assert "trust" not in out
@@ -320,8 +316,6 @@ class TestTrustTableAndJson:
         # description (the field must remain present, not be dropped by exclude_none).
         import json
 
-        import dep_rank.cli.formatters as fmt
-
         repo = Repository(
             owner="alpha",
             name="framework",
@@ -330,8 +324,8 @@ class TestTrustTableAndJson:
             description=None,  # must serialize as "description": null, not vanish
         )
         result = self._result(ranked_by="stars", repos=[repo])
-        with fmt.console.capture() as cap:
-            fmt.print_dependents_json(result, include_rank_metadata=False)
+        with console.capture() as cap:
+            print_dependents_json(result, include_rank_metadata=False)
         out = cap.get()
         assert '"description": null' in out  # key present with explicit null
         payload = json.loads(out)
@@ -349,11 +343,9 @@ class TestTrustTableAndJson:
         assert "ranked_by" not in payload
 
     def test_json_trust_mode_includes_metadata(self) -> None:
-        import dep_rank.cli.formatters as fmt
-
         result = self._result(ranked_by="trust", repos=[self._trust_repo()])
-        with fmt.console.capture() as cap:
-            fmt.print_dependents_json(result, include_rank_metadata=True)
+        with console.capture() as cap:
+            print_dependents_json(result, include_rank_metadata=True)
         out = cap.get()
         assert '"ranked_by": "trust"' in out
         assert '"score": 87.4' in out

--- a/tests/cli/test_formatters.py
+++ b/tests/cli/test_formatters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Literal
 
 from dep_rank.cli.formatters import (
     console,
@@ -269,7 +270,9 @@ class TestTrustTableAndJson:
             ),
         )
 
-    def _result(self, *, ranked_by: str, repos: list[Repository]) -> DependentsResult:
+    def _result(
+        self, *, ranked_by: Literal["stars", "trust"], repos: list[Repository]
+    ) -> DependentsResult:
         return DependentsResult(
             source="https://github.com/django/django",
             total_count=100,

--- a/tests/core/test_graphql.py
+++ b/tests/core/test_graphql.py
@@ -126,3 +126,215 @@ class TestEnrichWithGraphql:
                 enriched = await enrich_with_graphql(session, repos, token="fake-token")
         assert len(enriched) == 1
         assert enriched[0].stars == 100  # unchanged
+
+
+class TestBuildTrustQuery:
+    def test_includes_engagement_and_recency_fields(self) -> None:
+        from dep_rank.core.graphql import build_trust_query
+
+        q = build_trust_query([make_repo("django", "django")], include_description=False)
+        assert "stargazerCount" in q
+        assert "forkCount" in q
+        assert "issues(states: [OPEN, CLOSED])" in q
+        assert "pullRequests(states: [OPEN, CLOSED, MERGED])" in q
+        assert "pushedAt" in q
+        assert "description" not in q
+
+    def test_include_description_adds_field(self) -> None:
+        from dep_rank.core.graphql import build_trust_query
+
+        q = build_trust_query([make_repo("a", "b")], include_description=True)
+        assert "description" in q
+
+
+class TestEnrichWithTrustMetadata:
+    @pytest.mark.asyncio
+    async def test_populates_signals_and_marks_complete(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("django", "django", stars=80000)]
+        payload = {
+            "data": {
+                "repo_0": {
+                    "stargazerCount": 82400,
+                    "forkCount": 31000,
+                    "issues": {"totalCount": 500},
+                    "pullRequests": {"totalCount": 300},
+                    "pushedAt": "2026-05-01T12:00:00Z",
+                }
+            }
+        }
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=payload)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is False
+        assert result.complete is True
+        repo = result.repos[0]
+        assert repo.stars == 82400
+        assert repo.trust_signals is not None
+        assert repo.trust_signals.forks == 31000
+        assert repo.trust_signals.issues == 500
+        assert repo.trust_signals.pull_requests == 300
+        assert repo.trust_signals.pushed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_401_short_circuits_to_failed(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("a", "b")]
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", status=401)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="bad", include_description=False
+                )
+        assert result.failed is True
+        assert result.complete is False
+
+    @pytest.mark.asyncio
+    async def test_graphql_error_marks_failed_when_only_batch(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("a", "b")]
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload={"errors": [{"message": "boom"}]})
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is True  # the only batch errored -> no usable metadata
+
+    @pytest.mark.asyncio
+    async def test_missing_repo_data_is_partial_not_failed(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("a", "b"), make_repo("c", "d")]
+        payload = {
+            "data": {
+                "repo_0": {
+                    "stargazerCount": 10,
+                    "forkCount": 1,
+                    "issues": {"totalCount": 1},
+                    "pullRequests": {"totalCount": 1},
+                    "pushedAt": "2026-01-01T00:00:00Z",
+                }
+                # repo_1 missing
+            }
+        }
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=payload)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is False
+        assert result.complete is False
+        assert result.repos[0].trust_signals is not None
+        assert result.repos[1].trust_signals is None
+
+    @pytest.mark.asyncio
+    async def test_data_with_errors_is_partial_not_failed(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("a", "b"), make_repo("c", "d")]
+        payload = {
+            "data": {
+                "repo_0": {
+                    "stargazerCount": 10,
+                    "forkCount": 1,
+                    "issues": {"totalCount": 1},
+                    "pullRequests": {"totalCount": 1},
+                    "pushedAt": "2026-01-01T00:00:00Z",
+                },
+                "repo_1": None,
+            },
+            "errors": [{"message": "Could not resolve repo_1"}],
+        }
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=payload)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is False  # usable data present
+        assert result.complete is False  # errors -> incomplete
+        assert result.repos[0].trust_signals is not None
+        assert result.repos[1].trust_signals is None
+
+    @pytest.mark.asyncio
+    async def test_data_all_null_is_failed(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        # A data object whose every repo is null yields no usable trust_signals -> the
+        # batch produced nothing; with no other batch succeeding -> failed=True.
+        repos = [make_repo("a", "b")]
+        payload = {"data": {"repo_0": None}, "errors": [{"message": "Could not resolve"}]}
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=payload)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is True
+        assert result.complete is False
+        assert result.repos[0].trust_signals is None
+
+    @pytest.mark.asyncio
+    async def test_multi_batch_one_failed_is_partial(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo(f"o{i}", f"r{i}") for i in range(150)]  # 2 batches (100 + 50)
+        good = {
+            "data": {
+                f"repo_{i}": {
+                    "stargazerCount": i,
+                    "forkCount": 0,
+                    "issues": {"totalCount": 0},
+                    "pullRequests": {"totalCount": 0},
+                    "pushedAt": None,
+                }
+                for i in range(100)
+            }
+        }
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=good)  # batch 1 succeeds
+            m.post("https://api.github.com/graphql", status=500)  # batch 2 fails
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is False  # at least one batch succeeded
+        assert result.complete is False  # the other batch failed
+        assert len(result.repos) == 150
+        assert result.repos[0].trust_signals is not None
+        assert result.repos[100].trust_signals is None  # from the failed batch
+
+    @pytest.mark.asyncio
+    async def test_multi_batch_all_failed_is_failed(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo(f"o{i}", f"r{i}") for i in range(150)]  # 2 batches
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", status=500)  # batch 1 fails
+            m.post("https://api.github.com/graphql", status=500)  # batch 2 fails
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is True  # no usable metadata at all
+        assert result.complete is False
+
+    @pytest.mark.asyncio
+    async def test_empty_repos_is_clean(self) -> None:
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        async with ClientSession() as session:
+            result = await enrich_with_trust_metadata(
+                session, [], token="fake", include_description=False
+            )
+        assert result.repos == []
+        assert result.failed is False
+        assert result.complete is True

--- a/tests/core/test_graphql.py
+++ b/tests/core/test_graphql.py
@@ -181,6 +181,36 @@ class TestEnrichWithTrustMetadata:
         assert repo.trust_signals.pushed_at is not None
 
     @pytest.mark.asyncio
+    async def test_malformed_pushed_at_degrades_recency_not_crash(self) -> None:
+        # A non-ISO pushedAt must not abort the run; recency degrades to "missing"
+        # (pushed_at=None) while the rest of the signals are still applied.
+        from dep_rank.core.graphql import enrich_with_trust_metadata
+
+        repos = [make_repo("django", "django", stars=80000)]
+        payload = {
+            "data": {
+                "repo_0": {
+                    "stargazerCount": 82400,
+                    "forkCount": 31000,
+                    "issues": {"totalCount": 500},
+                    "pullRequests": {"totalCount": 300},
+                    "pushedAt": "not-a-date",
+                }
+            }
+        }
+        with aioresponses() as m:
+            m.post("https://api.github.com/graphql", payload=payload)
+            async with ClientSession() as session:
+                result = await enrich_with_trust_metadata(
+                    session, repos, token="fake", include_description=False
+                )
+        assert result.failed is False
+        repo = result.repos[0]
+        assert repo.trust_signals is not None
+        assert repo.trust_signals.pushed_at is None  # unparseable -> missing recency
+        assert repo.trust_signals.forks == 31000  # other signals intact
+
+    @pytest.mark.asyncio
     async def test_401_short_circuits_to_failed(self) -> None:
         from dep_rank.core.graphql import enrich_with_trust_metadata
 

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -15,6 +15,10 @@ from dep_rank.core.models import (
     Repository,
     ScrapeReason,
     ScrapeResult,
+    TrustComponents,
+    TrustMetadataResult,
+    TrustScore,
+    TrustSignals,
 )
 
 
@@ -330,3 +334,57 @@ class TestScrapeSnapshot:
         assert snap.done is True
         assert snap.complete is False
         assert snap.reason == "max_pages_reached"
+
+
+class TestTrustModels:
+    def test_repository_trust_fields_default_none(self) -> None:
+        repo = Repository(owner="a", name="b", url="https://github.com/a/b", stars=1)
+        assert repo.trust is None
+        assert repo.trust_signals is None
+
+    def test_trust_signals_excluded_from_serialization(self) -> None:
+        repo = Repository(
+            owner="a",
+            name="b",
+            url="https://github.com/a/b",
+            stars=1,
+            trust_signals=TrustSignals(forks=5, issues=3, pull_requests=2, pushed_at=None),
+        )
+        assert "trust_signals" not in repo.model_dump_json()
+        assert "trust_signals" not in repo.model_dump()
+
+    def test_trust_score_serializes_with_components(self) -> None:
+        repo = Repository(
+            owner="a",
+            name="b",
+            url="https://github.com/a/b",
+            stars=1,
+            trust=TrustScore(
+                score=72.5,
+                forks=5,
+                issues=3,
+                pull_requests=2,
+                pushed_at=None,
+                components=TrustComponents(stars=0.5, forks=0.4, engagement=0.3, recency=0.0),
+            ),
+        )
+        data = repo.model_dump_json()
+        assert '"score":72.5' in data
+        assert '"components"' in data
+
+    def test_dependents_result_ranked_by_defaults_to_stars(self) -> None:
+        result = DependentsResult(
+            source="https://github.com/x/y",
+            total_count=0,
+            filtered_count=0,
+            repos=[],
+            dependent_type=DependentType.REPOSITORY,
+            scraped_at=datetime.now(tz=UTC),
+        )
+        assert result.ranked_by == "stars"
+
+    def test_trust_metadata_result_fields(self) -> None:
+        res = TrustMetadataResult(repos=[], failed=False, complete=True)
+        assert res.repos == []
+        assert res.failed is False
+        assert res.complete is True

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -238,6 +238,21 @@ class TestDependentsResultContractFields:
         assert result.reason is None
         assert result.pages_scraped == 0
         assert result.estimated_total_pages == 0
+        assert result.ranked_by == "stars"  # default ranking strategy
+
+    def test_ranked_by_rejects_invalid_value(self) -> None:
+        # ranked_by is a Literal["stars", "trust"]; a typo fails fast at construction
+        # rather than silently rendering as the star branch downstream.
+        with pytest.raises(ValidationError):
+            DependentsResult(
+                source="https://github.com/x/y",
+                total_count=10,
+                filtered_count=10,
+                repos=[],
+                dependent_type=DependentType.REPOSITORY,
+                scraped_at=datetime.now(tz=UTC),
+                ranked_by="trsut",  # type: ignore[arg-type]
+            )
 
 
 class TestDependentsResultInvariant:

--- a/tests/core/test_trust.py
+++ b/tests/core/test_trust.py
@@ -1,0 +1,107 @@
+"""Tests for the pure trust-scoring function."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from dep_rank.core.models import Repository, TrustSignals
+from dep_rank.core.trust import compute_trust_scores
+
+
+def make_repo(
+    owner: str,
+    stars: int,
+    *,
+    forks: int | None = None,
+    issues: int | None = None,
+    prs: int | None = None,
+    pushed_at: datetime | None = None,
+    has_signals: bool = True,
+) -> Repository:
+    signals = (
+        TrustSignals(forks=forks, issues=issues, pull_requests=prs, pushed_at=pushed_at)
+        if has_signals
+        else None
+    )
+    return Repository(
+        owner=owner,
+        name="r",
+        url=f"https://github.com/{owner}/r",
+        stars=stars,
+        trust_signals=signals,
+    )
+
+
+def test_empty_pool_returns_empty() -> None:
+    assert compute_trust_scores([]) == []
+
+
+def test_engagement_can_outrank_stars() -> None:
+    # `low_star` has far more forks/issues/PRs and more recent activity; with stars
+    # weighted only 0.35 it should outrank the star-heavy but engagement-poor repo.
+    star_heavy = make_repo(
+        "starheavy", 100_000, forks=1, issues=0, prs=0, pushed_at=datetime(2015, 1, 1, tzinfo=UTC)
+    )
+    engaged = make_repo(
+        "engaged",
+        100,
+        forks=5_000,
+        issues=4_000,
+        prs=4_000,
+        pushed_at=datetime(2026, 5, 1, tzinfo=UTC),
+    )
+    ranked = compute_trust_scores([star_heavy, engaged])
+    assert ranked[0].owner == "engaged"
+
+
+def test_scores_are_0_to_100_and_populated() -> None:
+    repos = [
+        make_repo("a", 10, forks=1, issues=1, prs=1, pushed_at=datetime(2020, 1, 1, tzinfo=UTC)),
+        make_repo("b", 20, forks=2, issues=2, prs=2, pushed_at=datetime(2026, 1, 1, tzinfo=UTC)),
+    ]
+    ranked = compute_trust_scores(repos)
+    for repo in ranked:
+        assert repo.trust is not None
+        assert 0.0 <= repo.trust.score <= 100.0
+        assert repo.trust.components is not None
+
+
+def test_single_repo_pool_scores_50() -> None:
+    # Every component degenerate (single element) -> 0.5 each -> score 50.
+    repo = make_repo(
+        "solo", 5, forks=5, issues=5, prs=5, pushed_at=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+    ranked = compute_trust_scores([repo])
+    assert ranked[0].trust is not None
+    assert ranked[0].trust.score == 50.0
+
+
+def test_missing_signals_treated_as_weak() -> None:
+    # `none` has no signals at all: counts -> 0, recency -> 0.0. It must not outrank
+    # a repo with real engagement.
+    none = make_repo("none", 50, has_signals=False)
+    real = make_repo(
+        "real", 50, forks=100, issues=100, prs=100, pushed_at=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+    ranked = compute_trust_scores([none, real])
+    assert ranked[0].owner == "real"
+    assert ranked[-1].owner == "none"
+
+
+def test_missing_pushed_at_gets_zero_recency() -> None:
+    # Same counts; only difference is one repo has no pushed_at -> 0.0 recency, the
+    # other (present, single timestamp) -> degenerate 0.5. The dated repo wins.
+    dated = make_repo(
+        "dated", 10, forks=10, issues=10, prs=10, pushed_at=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+    undated = make_repo("undated", 10, forks=10, issues=10, prs=10, pushed_at=None)
+    ranked = compute_trust_scores([dated, undated])
+    assert ranked[0].owner == "dated"
+
+
+def test_deterministic_tie_break() -> None:
+    # Identical signals -> identical scores; ties break by stars desc then owner/name.
+    a = make_repo("alpha", 10, forks=1, issues=1, prs=1)
+    b = make_repo("bravo", 10, forks=1, issues=1, prs=1)
+    ranked = compute_trust_scores([b, a])
+    assert [r.owner for r in ranked] == ["alpha", "bravo"]


### PR DESCRIPTION
## Summary

Adds an opt-in `--rank-by [stars|trust]` flag to `dep-rank deps`. The default `stars` mode is byte-identical to prior releases; `trust` mode re-ranks the scraped candidate pool by a pool-relative composite score that blends stars with non-star signals (forks, total issues + pull requests, recency of activity), fetched in a single low-cost GitHub GraphQL query.

- **Data models** — `TrustSignals`/`TrustComponents`/`TrustScore`/`TrustMetadataResult`; `Repository.trust` (serialized) and `trust_signals` (`Field(exclude=True)`, never serialized); `DependentsResult.ranked_by`.
- **Pure scorer** (`core/trust.py`) — deterministic, clock-free, log-blended, min-max pool-normalized; weights stars 0.35 / forks 0.25 / engagement 0.20 / recency 0.20 (non-star majority).
- **GraphQL fetch** (`core/graphql.py`) — `build_trust_query` + `enrich_with_trust_metadata` returning a status-carrying result (401 → fail-fast; partial batches → `complete=False`; all-fail → fall back).
- **Formatters** — table branches on the *actual* ranking applied; JSON metadata gated so star-mode output stays byte-identical.
- **CLI wiring** — `--rank-by`, token preflight, deeper candidate pool in trust mode, graceful fallback to stars with honest `ranked_by` reporting.
- **README** — documents `--rank-by trust`, cites StarScout (stars are gameable), cites the GitHub GraphQL rate-limit docs, and states the ranking is heuristic and does **not** detect fake stars.

Trust ranking is a **pool-relative ranking signal, not an absolute quality score**, and does not fetch stargazer history, GHArchive data, or external fraud datasets.

## Test Plan

- [x] Full suite green: 244 passed, 95.03% coverage (gate 90%)
- [x] `ruff check` clean · `ruff format --check` clean · `mypy src/dep_rank/` clean
- [x] Default star ranking output/order unchanged (`test_star_json_unchanged_has_no_rank_metadata`, `test_flags_pass_through_and_counts_use_matched`)
- [x] Trust order, engagement-can-outrank-stars, deterministic tie-break (`tests/core/test_trust.py`)
- [x] Token required for trust mode with clear error (`test_trust_without_token_errors`)
- [x] Graceful fallback + honest `ranked_by` + warnings (`test_trust_fetch_failure_falls_back_to_stars`, `test_fallback_emits_warning_in_table_mode`, `test_partial_metadata_emits_warning_in_table_mode`)
- [x] JSON shape in trust mode (`test_trust_json_includes_metadata`); `trust_signals` never serialized
- [ ] Optional manual smoke with a real token: `DEP_RANK_TOKEN=ghp_... dep-rank deps https://github.com/pallets/click --rank-by trust --rows 5`

Fixes #117.
