### PR TITLE
fix(ci): unblock fork PRs on dependency-safety gate

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -1,0 +1,45 @@
+name: Dependency Safety Non-Bot Gate
+
+# Status-only gate for non-Dependabot pull requests.
+#
+# External fork PRs get a read-only GITHUB_TOKEN under `pull_request`, so the
+# reusable dependency-safety scanner cannot write the required
+# `dependency-safety / gate` commit status and the PR is wedged by the ruleset.
+# This workflow runs under `pull_request_target` (base-branch privileges) and
+# posts ONLY that required status. It deliberately performs NO checkout, NO
+# dependency install, NO build/test, and uses NO third-party actions and NO
+# PR-authored file - the only shell executed is the inline `gh api` call below.
+# That no-PR-code-execution property is what makes the privileged trigger safe.
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] status-only path; never checks out or runs PR code
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: dep-safety-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # Dependabot PRs are handled by the real reusable scanner in
+    # dependency-safety.yml; every other PR gets this status-only gate.
+    # `pull_request.user.login` is the spoofing-resistant actor field.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Post dependency-safety gate status
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context="dependency-safety / gate" \
+            -f description="Non-bot PR: no dependency cooldown scan required" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -16,6 +16,11 @@ concurrency:
 
 jobs:
   safety:
+    # Real dependency-safety scan runs for Dependabot only; every other PR (human
+    # fork, same-repo branch, other bot) gets the status-only gate in
+    # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
+    # spoofing-resistant actor field (zizmor bot-conditions).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
     with:
       auto_merge: true


### PR DESCRIPTION
Adds a status-only `pull_request_target` gate so non-Dependabot PRs (incl.
external forks) can satisfy the required `dependency-safety / gate` status, and
limits the privileged reusable scanner to Dependabot.

- `dependency-safety.yml`: `safety` job now runs only for `dependabot[bot]`.
- `dependency-safety-non-bot-gate.yml` (new): posts the required status for every
  other PR. No checkout, no third-party actions, no PR-authored code — status
  only. `dangerous-triggers` is suppressed inline at the trigger with a
  justifying comment.

Required ruleset context is the plain commit status `dependency-safety / gate`
(no reusable check-run is required), so gating `safety` to Dependabot strands no
required check.

Fixes #124.