### PR TITLE
ci: bump shared-workflows refs to v3.0.2

### DIFF
--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,6 +21,6 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field (zizmor bot-conditions).
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
     with:
       auto_merge: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@522610f12d08a8fe358569d6c533c21af6ac8ec0 # v3.0.1
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
Bumps both `j7an/shared-workflows` reusable-workflow callers under `.github/workflows/` from the v3.0.1 pinned SHA to the v3.0.2 dereferenced commit SHA `29bcd576f856e85042ab699dce66523711a44b48`.

- `dependency-safety.yml` — Dependabot-only real scan; split unchanged.
- `tag-release.yml` — ref only; inputs/secrets unchanged.
- `dependency-safety-non-bot-gate.yml` — untouched; still posts the status-only `dependency-safety / gate`.

Validated with `actionlint` and `zizmor` on the changed files.

Fixes #127.