### PR TITLE
ci(deps): bump shared-workflows callers to v4.0.0 (advisory release-age policy)

### DIFF
--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -41,5 +41,5 @@ jobs:
           gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
             -f state=success \
             -f context="dependency-safety / gate" \
-            -f description="Non-bot PR: no dependency cooldown scan required" \
+            -f description="Non-bot PR: dependency-safety scan not required" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,6 +21,8 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field (zizmor bot-conditions).
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
     with:
       auto_merge: true
+      release_age_policy: advisory
+      minimum_release_age_days: 5

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@29bcd576f856e85042ab699dce66523711a44b48 # v3.0.2
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"


### PR DESCRIPTION
## What

Bumps both `j7an/shared-workflows` callers from v3.0.2 (`29bcd576`) to
v4.0.0 (`dd7254ccf917f2e8385f209986b6139ac4651b88`).

v4 makes post-PR release-age verification opt-in: the old `fail_on_age_violation`
boolean is removed and `release_age_policy` now defaults to `"off"`. In v3.0.2 an
unset field meant **blocking**, so a plain ref bump would silently drop
release-age enforcement. This PR adopts **`release_age_policy: advisory`** as an
explicit, documented choice.

## Changes

- `dependency-safety.yml`: ref -> v4.0.0; add `release_age_policy: advisory` and
  `minimum_release_age_days: 5` (matches Dependabot `cooldown.default-days: 5`);
  keep `auto_merge: true`.
- `tag-release.yml`: ref -> v4.0.0 (pure ref bump; v4 input/secret contract
  unchanged).
- `dependency-safety-non-bot-gate.yml`: refresh stale "cooldown scan" wording to
  "dependency-safety scan not required". The `pull_request_target` gate is
  otherwise preserved -- ruleset 14481627 still requires `dependency-safety / gate`.

## Behavior delta

- Version-update PRs: Dependabot cooldown already ages them, so the advisory
  check passes -> unchanged (clean scan -> auto-merge).
- Security-update PRs: Dependabot `cooldown` does not apply to security updates,
  so these can arrive young. v3 (blocking) would have failed the gate; under
  advisory the gate stays green but the PR is labeled `dependency-age-violation`
  and auto-merge is suppressed for manual review.
- Non-bot / fork PRs: unchanged.

## Validation

- Scoped grep: both callers at the v4.0.0 SHA, no v3 remnants, no
  `fail_on_age_violation`.
- `actionlint` clean on all three workflows.
- `zizmor` reports `No findings to report.` (only the gate file's pre-existing
  `# zizmor: ignore[dangerous-triggers]` suppression).
- Ruleset `14481627` confirmed active and still requiring `dependency-safety / gate`.

## Post-merge acceptance check (follow-up, not a blocker)

Watch the next real Dependabot PR to confirm the v4 scan posts
`dependency-safety / gate` (pending -> success), a young target is labeled
`dependency-age-violation` with auto-merge suppressed, and a clean aged target
auto-merges. The v4 scan path runs only for Dependabot PRs, so it is validated
in production.
