### PR TITLE
ci: adopt shared-workflows v4.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           client-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/dependency-safety-non-bot-gate.yml
+++ b/.github/workflows/dependency-safety-non-bot-gate.yml
@@ -1,16 +1,5 @@
 name: Dependency Safety Non-Bot Gate
 
-# Status-only gate for non-Dependabot pull requests.
-#
-# External fork PRs get a read-only GITHUB_TOKEN under `pull_request`, so the
-# reusable dependency-safety scanner cannot write the required
-# `dependency-safety / gate` commit status and the PR is wedged by the ruleset.
-# This workflow runs under `pull_request_target` (base-branch privileges) and
-# posts ONLY that required status. It deliberately performs NO checkout, NO
-# dependency install, NO build/test, and uses NO third-party actions and NO
-# PR-authored file - the only shell executed is the inline `gh api` call below.
-# That no-PR-code-execution property is what makes the privileged trigger safe.
-
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] status-only path; never checks out or runs PR code
     types: [opened, synchronize, reopened]
@@ -24,22 +13,6 @@ concurrency:
 
 jobs:
   gate:
-    # Dependabot PRs are handled by the real reusable scanner in
-    # dependency-safety.yml; every other PR gets this status-only gate.
-    # `pull_request.user.login` is the spoofing-resistant actor field.
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: ubuntu-latest
     permissions:
       statuses: write
-    steps:
-      - name: Post dependency-safety gate status
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          gh api "repos/${GH_REPO}/statuses/${HEAD_SHA}" \
-            -f state=success \
-            -f context="dependency-safety / gate" \
-            -f description="Non-bot PR: dependency-safety scan not required" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety-non-bot-gate.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0

--- a/.github/workflows/dependency-safety.yml
+++ b/.github/workflows/dependency-safety.yml
@@ -21,7 +21,7 @@ jobs:
     # dependency-safety-non-bot-gate.yml. `pull_request.user.login` is the
     # spoofing-resistant actor field (zizmor bot-conditions).
     if: github.event.pull_request.user.login == 'dependabot[bot]'
-    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
+    uses: j7an/shared-workflows/.github/workflows/dependency-safety.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
     with:
       auto_merge: true
       release_age_policy: advisory

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -2,54 +2,19 @@ name: Pre-commit Autoupdate
 
 on:
   schedule:
-    - cron: "0 8 * * 1"  # Monday 08:00 UTC
+    - cron: "0 8 * * 1"
   workflow_dispatch:
 
 permissions: {}
 
+concurrency:
+  group: pre-commit-autoupdate
+  cancel-in-progress: true
+
 jobs:
   autoupdate:
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          client-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      - name: Install pre-commit
-        run: uv run pre-commit --version
-      - name: Run pre-commit autoupdate
-        run: uv run pre-commit autoupdate
-      - name: Check for changes
-        id: diff
-        run: |
-          if git diff --quiet .pre-commit-config.yaml; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Create Pull Request
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          branch: deps/pre-commit-autoupdate
-          title: "deps: update pre-commit hooks"
-          commit-message: "deps: update pre-commit hooks"
-          sign-commits: true
-          add-paths: .pre-commit-config.yaml
-          body: |
-            Automated update of pre-commit hook versions via `pre-commit autoupdate`.
-
-            Review the diff to verify hook version changes are expected.
-          labels: dependencies
+    uses: j7an/shared-workflows/.github/workflows/pre-commit-autoupdate.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
+    secrets:
+      RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,21 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 permissions:
   contents: read
+
+concurrency:
+  group: pypi-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_NAME: dep-rank
+  PACKAGE_DIR: .
+  VERIFY_COMMAND: dep-rank --version
+  DRAFT_RELEASE: "true"
+  ATTACH_ASSETS: "true"
 
 jobs:
   test:
@@ -17,7 +28,7 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-uv
@@ -34,41 +45,35 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout at tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
-          fetch-tags: true
-
-      - name: Verify tag is on main
+      - name: Verify tag is ancestor of main
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
+          TAG_SHA=$(git rev-list -n1 "$TAG")
           git fetch origin main
-          if ! git merge-base --is-ancestor ${{ github.sha }} origin/main; then
-            echo "ERROR: Tagged commit $(git rev-parse --short HEAD) is not on main"
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "::error::Tag ${TAG} (${TAG_SHA}) is not an ancestor of origin/main"
             exit 1
           fi
-
       - uses: ./.github/actions/setup-uv
-
-      - name: Build sdist and wheel
+      - name: Build wheel and sdist
+        working-directory: ${{ env.PACKAGE_DIR }}
         run: uv build
-
-      - name: Verify distributions
-        run: |
-          ls -la dist/
-          WHEEL=$(ls dist/*.whl 2>/dev/null | wc -l)
-          SDIST=$(ls dist/*.tar.gz 2>/dev/null | wc -l)
-          if [ "$WHEEL" -eq 0 ] || [ "$SDIST" -eq 0 ]; then
-            echo "ERROR: Expected both a wheel and sdist in dist/"
-            ls dist/
-            exit 1
-          fi
-          echo "Build produced: $(ls dist/)"
-
-      - name: Upload build artifacts
+      - name: Verify built version matches tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: bash scripts/derive-published-version.sh "${PACKAGE_DIR}/dist" "$TAG"
+      - name: Upload dist artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist
-          path: dist/
+          name: pypi-dist
+          path: ${{ env.PACKAGE_DIR }}/dist/
+          if-no-files-found: error
           retention-days: 7
 
   publish-testpypi:
@@ -86,49 +91,81 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - name: Download build artifacts
+      - name: Download dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
+          name: pypi-dist
           path: dist/
-
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
+          packages-dir: dist/
+          skip-existing: false
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+  verify-testpypi:
+    name: Verify TestPyPI install
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          python-version: "3.13"
-
-      - name: Verify TestPyPI install
+          egress-policy: audit
+      - name: Set up uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Verify install from TestPyPI
+        env:
+          PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+          VERIFY_COMMAND: ${{ env.VERIFY_COMMAND }}
+          VERSION_TAG: ${{ github.ref_name }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          echo "Waiting for dep-rank==${VERSION} to appear on TestPyPI..."
-          for i in 1 2 3 4 5; do
-            sleep $((i * 30))
-            if pip install \
+          VERSION="${VERSION_TAG##*/}"
+          VERSION="${VERSION#v}"
+          echo "Verifying TestPyPI install of ${PACKAGE_NAME}==${VERSION}"
+          INSTALLED=false
+          ATTEMPT=0
+          for SLEEP_SECONDS in 30 60 90 120 150; do
+            ATTEMPT=$((ATTEMPT + 1))
+            echo "Attempt ${ATTEMPT}/5: sleeping ${SLEEP_SECONDS}s before install..."
+            sleep "$SLEEP_SECONDS"
+            rm -rf .verify
+            uv venv .verify
+            . .verify/bin/activate
+            if uv pip install \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple/ \
-              "dep-rank==${VERSION}" 2>/dev/null; then
-              ACTUAL=$(dep-rank --version 2>&1)
-              echo "Installed version: ${ACTUAL}"
-              echo "${ACTUAL}" | grep -qF "${VERSION}" || {
-                echo "ERROR: Expected '${VERSION}' in dep-rank --version output"
-                exit 1
-              }
-              echo "TestPyPI install OK"
-              exit 0
+              "${PACKAGE_NAME}==${VERSION}"; then
+              INSTALLED=true
+              break
             fi
-            echo "Attempt $i: not yet available, retrying..."
+            echo "Attempt ${ATTEMPT} failed; retrying."
           done
-          echo "ERROR: dep-rank==${VERSION} not available on TestPyPI after 7.5 minutes"
-          exit 1
+          if [ "$INSTALLED" != "true" ]; then
+            echo "::error::TestPyPI install verification failed after 5 attempts"
+            exit 1
+          fi
+          if [ -n "${VERIFY_COMMAND:-}" ]; then
+            if ! VERIFY_OUTPUT=$(bash -euo pipefail -c "$VERIFY_COMMAND" 2>&1); then
+              printf '%s\n' "$VERIFY_OUTPUT"
+              echo "::error::Verification command failed"
+              exit 1
+            fi
+            printf '%s\n' "$VERIFY_OUTPUT"
+            case "$VERIFY_OUTPUT" in
+              *"$VERSION"*) ;;
+              *)
+                echo "::error::Verification command output did not contain version '${VERSION}'"
+                exit 1
+                ;;
+            esac
+          fi
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [build, publish-testpypi]
+    needs: verify-testpypi
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -141,19 +178,19 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - name: Download build artifacts
+      - name: Download dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
+          name: pypi-dist
           path: dist/
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          packages-dir: dist/
 
   github-release:
     name: Create GitHub Release
-    needs: [build, publish-pypi]
-    if: needs.publish-pypi.result == 'success'
+    needs: publish-pypi
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -162,31 +199,33 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Checkout at tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          fetch-depth: 0
-
-      - name: Download build artifacts
+          ref: ${{ github.ref_name }}
+      - name: Download dist artifact
+        if: env.ATTACH_ASSETS == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
+          name: pypi-dist
           path: dist/
-
-      - name: Classify tag (stable vs prerelease)
-        id: classify
+      - name: Create GitHub Release
         env:
-          REF: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION_TAG: ${{ github.ref_name }}
         run: |
-          if [[ "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.post[0-9]+)?$ ]]; then
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          VERSION="${VERSION_TAG##*/}"
+          VERSION="${VERSION#v}"
+          IS_PRERELEASE=$(bash scripts/classify-prerelease.sh "$VERSION")
+          ARGS=( "$TAG" --generate-notes --title "$TAG" )
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            ARGS+=( --prerelease )
           fi
-
-      - name: Create GitHub Release with assets
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          generate_release_notes: true
-          draft: true
-          prerelease: ${{ steps.classify.outputs.prerelease }}
-          files: dist/*
+          if [ "$DRAFT_RELEASE" = "true" ]; then
+            ARGS+=( --draft )
+          fi
+          if [ "$ATTACH_ASSETS" = "true" ]; then
+            ARGS+=( dist/*.whl dist/*.tar.gz )
+          fi
+          gh release create "${ARGS[@]}"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
     branches: [main]
   schedule:
-    - cron: "0 6 * * 1" # Weekly Monday 06:00 UTC
+    - cron: "0 6 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,144 +17,12 @@ concurrency:
 permissions: {}
 
 jobs:
-  codeql:
-    name: CodeQL
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          languages: python
-          queries: +security-and-quality
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          category: "/language:python"
-
-  trufflehog:
-    name: TruffleHog
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: TruffleHog secret scan
-        id: trufflehog
-        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
-        continue-on-error: true
-        with:
-          path: ./
-          base: ${{ github.event.pull_request.base.sha || github.event.before }}
-          head: ${{ github.event.pull_request.head.sha || github.event.after }}
-          extra_args: --only-verified
-
-      - name: Fail on verified secrets
-        if: steps.trufflehog.outcome == 'failure'
-        run: |
-          echo "::error::TruffleHog detected verified secrets. Review the scan output above."
-          exit 1
-
-  zizmor:
-    name: Zizmor
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run Zizmor
-        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
-        with:
-          version: "1.24.1"
-          min-severity: medium
-          min-confidence: medium
-
-  trivy:
-    name: Trivy
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Generate SARIF report
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          scan-type: repo
-          format: sarif
-          output: trivy-results.sarif
-
-      - name: Upload Trivy results to GitHub Security tab
-        if: always()
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy
-
-      - name: Fail on CRITICAL/HIGH vulnerabilities
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          scan-type: repo
-          format: table
-          severity: CRITICAL,HIGH
-          exit-code: "1"
-
-  osv-scan:
-    name: OSV-Scanner
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+  security:
     permissions:
       actions: read
       contents: read
       security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    uses: j7an/shared-workflows/.github/workflows/security-scan.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
     with:
-      scan-args: --recursive ./
-
-  osv-scan-pr:
-    name: OSV-Scanner PR
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-    with:
-      scan-args: --recursive ./
+      support_merge_group: true
+      codeql_queries: +security-and-quality

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   tag:
-    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@dd7254ccf917f2e8385f209986b6139ac4651b88 # v4.0.0
+    uses: j7an/shared-workflows/.github/workflows/tag-release.yml@5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0
     with:
       bump: ${{ inputs.bump }}
       tag-prefix: "v"

--- a/scripts/classify-prerelease.sh
+++ b/scripts/classify-prerelease.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# classify-prerelease.sh - classify a normalized PyPI-publishable version.
+#
+# Caller-copy reference: this script is a canonical reference for package
+# release workflows in caller repos. It has no local inline workflow consumer in
+# shared-workflows and is intentionally excluded from check-inline-sync.sh
+# INLINE_PAIRS.
+#
+# Input contract: exactly one normalized, PyPI-publishable version. Local
+# versions containing '+label' are unsupported because PyPI publish artifacts
+# should not use local versions.
+#
+# Output:
+#   true  - version is a pre-release or dev release
+#   false - version is stable or post-release only
+#
+# Exit:
+#   0 - classified successfully
+#   2 - malformed or unsupported input
+#
+# Bash 3.2 compatible.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <normalized-pypi-version>" >&2
+  exit 2
+fi
+
+version="$1"
+
+if [ -z "$version" ]; then
+  echo "version must not be empty" >&2
+  exit 2
+fi
+
+case "$version" in
+  *+*)
+    echo "local versions are unsupported input: $version" >&2
+    exit 2
+    ;;
+esac
+
+if printf '%s\n' "$version" | grep -Eq '(a|b|rc)[0-9]|\.dev[0-9]'; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/scripts/derive-published-version.sh
+++ b/scripts/derive-published-version.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# derive-published-version.sh - derive and verify the version being published.
+#
+# Caller-copy reference: this script is a canonical reference for package
+# release workflows in caller repos. It has no local inline workflow consumer in
+# shared-workflows and is intentionally excluded from check-inline-sync.sh
+# INLINE_PAIRS.
+#
+# Usage:
+#   scripts/derive-published-version.sh <dist-dir> <tag>
+#
+# Output:
+#   normalized artifact version on stdout
+#
+# Exit:
+#   0 - exactly one wheel, exactly one sdist, and tag tail equals wheel version
+#   1 - artifact count error or tag/artifact mismatch
+#   2 - malformed invocation
+#
+# Bash 3.2 compatible.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <dist-dir> <tag>" >&2
+  exit 2
+fi
+
+dist_dir="$1"
+tag="$2"
+
+if [ ! -d "$dist_dir" ]; then
+  echo "dist directory does not exist: $dist_dir" >&2
+  exit 1
+fi
+
+count_matches() {
+  find "$1" -maxdepth 1 -type f -name "$2" | wc -l | tr -d '[:space:]'
+}
+
+first_match() {
+  find "$1" -maxdepth 1 -type f -name "$2" | sed -n '1p'
+}
+
+wheel_count=$(count_matches "$dist_dir" '*.whl')
+sdist_count=$(count_matches "$dist_dir" '*.tar.gz')
+
+if [ "$wheel_count" -ne 1 ]; then
+  echo "expected exactly one wheel in $dist_dir, found $wheel_count" >&2
+  exit 1
+fi
+
+if [ "$sdist_count" -ne 1 ]; then
+  echo "expected exactly one sdist in $dist_dir, found $sdist_count" >&2
+  exit 1
+fi
+
+wheel_path=$(first_match "$dist_dir" '*.whl')
+wheel_base="${wheel_path##*/}"
+
+artifact_remainder="${wheel_base#*-}"
+artifact_version="${artifact_remainder%%-*}"
+
+if [ -z "$artifact_version" ] || [ "$artifact_version" = "$wheel_base" ]; then
+  echo "could not derive version from wheel filename: $wheel_base" >&2
+  exit 1
+fi
+
+tag_tail="${tag##*/}"
+tag_tail="${tag_tail#v}"
+
+if [ "$tag_tail" != "$artifact_version" ]; then
+  echo "Tag tail '$tag_tail' does not equal built version '$artifact_version'." >&2
+  echo "Tag the canonical normalized version, e.g. 'v${artifact_version}', or update project metadata." >&2
+  exit 1
+fi
+
+printf '%s\n' "$artifact_version"


### PR DESCRIPTION
## Summary

- Migrate the non-bot dependency-safety gate, pre-commit autoupdate, and security scanner workflows to shared-workflows v4.1.0 thin callers.
- Bump the existing dependency-safety and tag-release callers to `5997f2092ef3fea11a5bcdca8ec81382bcc30eba # v4.1.0`.
- Align the caller-local PyPI release workflow with the shared-workflows caller-owned Trusted Publishing template.
- Scope the Dependabot lockfile-repair App token to `contents: write` so the shared Zizmor scan passes without broad installation permissions.

## Repo-specific choices

- Keep the `dependency-safety / gate` status contract unchanged; Dependabot keeps the scanner path and non-Dependabot PRs use the status-only gate.
- Use the App-token pre-commit autoupdate caller with explicit `RELEASE_BOT_PRIVATE_KEY` secret mapping.
- Preserve security merge-queue support with `support_merge_group: true` and CodeQL quality queries with `codeql_queries: +security-and-quality`.
- Keep PyPI/TestPyPI publishing caller-local for OIDC Trusted Publishing; the next intended tag exercises the release path.

## Verification

- `rtk actionlint .github/workflows/*.yml`
- `rtk bash -n scripts/derive-published-version.sh scripts/classify-prerelease.sh`
- `rtk git diff --check origin/main..HEAD`
- stale-pin search over `.github/workflows` and `scripts`
- `rtk uv run ruff check src/ tests/`
- `rtk uv run mypy src/dep_rank/`
- `rtk uv run pytest --no-cov` (246 passed)
- `rtk zizmor --min-severity=medium --min-confidence=medium .github/workflows`
- helper scripts byte-for-byte compared against shared-workflows `v4.1.0`
- live ruleset inspection confirmed no security check rename is required
- PR checks on draft #143: all required checks passing; `dependency-safety / gate` posted successfully

Fixes #140
Refs j7an/shared-workflows#91
